### PR TITLE
Fixed bug in BasicAuthenticationHandler

### DIFF
--- a/src/HttPlaceholder.Application.Tests/StubExecution/RequestStubGeneration/BasicAuthenticationHandlerFacts.cs
+++ b/src/HttPlaceholder.Application.Tests/StubExecution/RequestStubGeneration/BasicAuthenticationHandlerFacts.cs
@@ -57,6 +57,30 @@ namespace HttPlaceholder.Application.Tests.StubExecution.RequestStubGeneration
         }
 
         [TestMethod]
+        public async Task BasicAuthenticationHandler_HandleStubGenerationAsync_AuthorizationIsBearer_ShouldReturnFalse()
+        {
+            // Arrange
+            var stub = new StubModel();
+            var request = new RequestResultModel
+            {
+                RequestParameters = new RequestParametersModel
+                {
+                    Headers = new Dictionary<string, string>
+                    {
+                        { "Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c" }
+                    }
+                }
+            };
+
+            // Act
+            var result = await _handler.HandleStubGenerationAsync(request, stub);
+
+            // Assert
+            Assert.IsFalse(result);
+            Assert.IsNull(stub.Conditions.BasicAuthentication);
+        }
+
+        [TestMethod]
         public async Task BasicAuthenticationHandler_HandleStubGenerationAsync_HappyFlow()
         {
             // Arrange

--- a/src/HttPlaceholder.Application/StubExecution/RequestStubGeneration/Implementations/BasicAuthenticationHandler.cs
+++ b/src/HttPlaceholder.Application/StubExecution/RequestStubGeneration/Implementations/BasicAuthenticationHandler.cs
@@ -12,7 +12,7 @@ namespace HttPlaceholder.Application.StubExecution.RequestStubGeneration.Impleme
         {
             var pair = request.RequestParameters.Headers.FirstOrDefault(p =>
                 p.Key.Equals("Authorization", StringComparison.OrdinalIgnoreCase));
-            if (string.IsNullOrWhiteSpace(pair.Value))
+            if (string.IsNullOrWhiteSpace(pair.Value) || pair.Value.Trim().StartsWith("Bearer", StringComparison.OrdinalIgnoreCase))
             {
                 return Task.FromResult(false);
             }

--- a/src/HttPlaceholder.Application/StubExecution/RequestStubGeneration/Implementations/BasicAuthenticationHandler.cs
+++ b/src/HttPlaceholder.Application/StubExecution/RequestStubGeneration/Implementations/BasicAuthenticationHandler.cs
@@ -12,7 +12,7 @@ namespace HttPlaceholder.Application.StubExecution.RequestStubGeneration.Impleme
         {
             var pair = request.RequestParameters.Headers.FirstOrDefault(p =>
                 p.Key.Equals("Authorization", StringComparison.OrdinalIgnoreCase));
-            if (string.IsNullOrWhiteSpace(pair.Value) || pair.Value.Trim().StartsWith("Bearer", StringComparison.OrdinalIgnoreCase))
+            if (string.IsNullOrWhiteSpace(pair.Value) || !pair.Value.Trim().ToLower().StartsWith("Basic", StringComparison.OrdinalIgnoreCase))
             {
                 return Task.FromResult(false);
             }


### PR DESCRIPTION
When creating a stub from request with an "Authorization" header other than basic, HttPlaceholder would throw an exception. I've added a check on if the Authorization header starts with "Basic".