### PR TITLE
Fixed header issues in reverse proxy writer

### DIFF
--- a/src/HttPlaceholder.Application.Tests/StubExecution/ResponseWriting/ReverseProxyResponseWriterFacts.cs
+++ b/src/HttPlaceholder.Application.Tests/StubExecution/ResponseWriting/ReverseProxyResponseWriterFacts.cs
@@ -245,6 +245,7 @@ namespace HttPlaceholder.Application.Tests.StubExecution.ResponseWriting
                 .Returns(mockHttp.ToHttpClient());
 
             var responseModel = new ResponseModel();
+            responseModel.Headers.Add("Some-Date", "2020-08-11");
 
             // Act
             var result = await _writer.WriteToResponseAsync(stub, responseModel);
@@ -254,8 +255,7 @@ namespace HttPlaceholder.Application.Tests.StubExecution.ResponseWriting
             Assert.AreEqual(200, responseModel.StatusCode);
             Assert.IsTrue(result.Executed);
 
-            Assert.AreEqual(4, responseModel.Headers.Count);
-            Assert.AreEqual("2", responseModel.Headers["Content-Length"]);
+            Assert.AreEqual(3, responseModel.Headers.Count);
             Assert.AreEqual("text/plain; charset=utf-8", responseModel.Headers["Content-Type"]);
             Assert.AreEqual("2020-08-16", responseModel.Headers["Some-Date"]);
             Assert.AreEqual("abc123", responseModel.Headers["Token"]);

--- a/src/HttPlaceholder.Application/StubExecution/ResponseWriting/Implementations/ReverseProxyResponseWriter.cs
+++ b/src/HttPlaceholder.Application/StubExecution/ResponseWriting/Implementations/ReverseProxyResponseWriter.cs
@@ -19,7 +19,7 @@ namespace HttPlaceholder.Application.StubExecution.ResponseWriting.Implementatio
 
         private static readonly string[] _excludedResponseHeaderNames =
         {
-            "x-httplaceholder-correlation", "transfer-encoding"
+            "x-httplaceholder-correlation", "transfer-encoding", "content-length"
         };
 
         private readonly IHttpClientFactory _httpClientFactory;
@@ -127,7 +127,7 @@ namespace HttPlaceholder.Application.StubExecution.ResponseWriting.Implementatio
                 .ToArray();
             foreach (var header in responseHeaders)
             {
-                response.Headers.Add(header.Key, header.Value);
+                response.Headers.AddOrReplaceCaseInsensitive(header.Key, header.Value);
             }
 
             response.StatusCode = (int)responseMessage.StatusCode;


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

* Whenever a "Content-Length" header is returned by the proxied URL, HttPlaceholder throws an exception. The header should be filtered out.
* Whenever any header is already set by another response writer and it is also returned by the proxied response, HttPlaceholder will throw an exception. Any existing header needs to be replaced by the header from the proxy response.

Issue Number: N/A

## What is the new behavior?

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
