### PR TITLE
Close form helpers list on escape press

### DIFF
--- a/guiv3/src/components/stub/FormHelperSelector.vue
+++ b/guiv3/src/components/stub/FormHelperSelector.vue
@@ -12,9 +12,10 @@
         <input
           type="text"
           class="form-control"
-          placeholder="Filter form helpers..."
+          placeholder="Filter form helpers (press 'Escape' to close)..."
           v-model="formHelperFilter"
           ref="formHelperFilterInput"
+          @keyup.esc="closeFormHelperAndList"
         />
       </div>
       <div class="list-group">
@@ -117,6 +118,11 @@ export default {
         }
       }, 10);
     };
+    const closeFormHelperAndList = () => {
+      formHelperFilter.value = "";
+      store.commit("stubForm/closeFormHelper");
+      showFormHelperItems.value = false;
+    };
 
     // Computed
     const currentSelectedFormHelper = computed(
@@ -154,6 +160,7 @@ export default {
       formHelperFilter,
       formHelperFilterInput,
       openFormHelperList,
+      closeFormHelperAndList,
     };
   },
 };


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

The form helper list in the UI can now only be closed when selecting a form helper. Pressing the escape button should also close it.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
