### PR TITLE
Refactoring/docker verbose logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ COPY --from=build-env /app/out .
 COPY --from=gui-build-env /app/gui/dist ./gui
 ENV inputFile=/var/httplaceholder
 RUN mkdir /var/httplaceholder
-ENTRYPOINT ["dotnet", "HttPlaceholder.dll", "-V"]
+ENTRYPOINT ["dotnet", "HttPlaceholder.dll"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,3 @@
+# Docker examples
+
+In this folder, you'll find a few Docker Compose examples on how you can run HttPlaceholder using a Docker container.

--- a/docker/httplaceholder-with-file-storage/docker-compose.yml
+++ b/docker/httplaceholder-with-file-storage/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     image: dukeofharen/httplaceholder:latest
     environment:
       fileStorageLocation: '/etc/httplaceholder'
+      verbose: 'true'
     ports:
       - 5000:5000
     restart: on-failure

--- a/docker/httplaceholder-with-mariadb/docker-compose.yml
+++ b/docker/httplaceholder-with-mariadb/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     image: dukeofharen/httplaceholder:latest
     environment:
       mysqlConnectionString: 'Server=mariadb;Database=httplaceholder;Uid=httplaceholder;Pwd=httplaceholder;Allow User Variables=true'
+      verbose: 'true'
     ports:
       - 5000:5000
     restart: on-failure

--- a/docker/httplaceholder-with-mariadb/docker-compose.yml
+++ b/docker/httplaceholder-with-mariadb/docker-compose.yml
@@ -1,4 +1,4 @@
-# A Docker Compose example that starts HttPlaceholder with a MySQL database, so all stubs (that are made through the UI or API) and requests are saved to the database.
+# A Docker Compose example that starts HttPlaceholder with a MariaDB database, so all stubs (that are made through the UI or API) and requests are saved to the database.
 version: '3.8'
 services:
   httplaceholder:

--- a/docker/httplaceholder-with-mssql/docker-compose.yml
+++ b/docker/httplaceholder-with-mssql/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     image: dukeofharen/httplaceholder:latest
     environment:
       sqlServerConnectionString: 'Server=mssql,1433;Database=httplaceholder;User Id=sa;Password=Password123!'
+      verbose: 'true'
     ports:
       - 5000:5000
     restart: on-failure

--- a/docker/httplaceholder-with-mysql5/docker-compose.yml
+++ b/docker/httplaceholder-with-mysql5/docker-compose.yml
@@ -1,4 +1,4 @@
-# A Docker Compose example that starts HttPlaceholder with a MySQL database, so all stubs (that are made through the UI or API) and requests are saved to the database.
+# A Docker Compose example that starts HttPlaceholder with a MySQL 5 database, so all stubs (that are made through the UI or API) and requests are saved to the database.
 version: '3.8'
 services:
   httplaceholder:

--- a/docker/httplaceholder-with-mysql5/docker-compose.yml
+++ b/docker/httplaceholder-with-mysql5/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     image: dukeofharen/httplaceholder:latest
     environment:
       mysqlConnectionString: 'Server=mysql;Database=httplaceholder;Uid=httplaceholder;Pwd=httplaceholder;Allow User Variables=true'
+      verbose: 'true'
     ports:
       - 5000:5000
     restart: on-failure

--- a/docker/httplaceholder-with-mysql8/docker-compose.yml
+++ b/docker/httplaceholder-with-mysql8/docker-compose.yml
@@ -1,4 +1,4 @@
-# A Docker Compose example that starts HttPlaceholder with a MySQL database, so all stubs (that are made through the UI or API) and requests are saved to the database.
+# A Docker Compose example that starts HttPlaceholder with a MySQL 8 database, so all stubs (that are made through the UI or API) and requests are saved to the database.
 version: '3.8'
 services:
   httplaceholder:

--- a/docker/httplaceholder-with-mysql8/docker-compose.yml
+++ b/docker/httplaceholder-with-mysql8/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     image: dukeofharen/httplaceholder:latest
     environment:
       mysqlConnectionString: 'Server=mysql;Database=httplaceholder;Uid=httplaceholder;Pwd=httplaceholder;Allow User Variables=true'
+      verbose: 'true'
     ports:
       - 5000:5000
     restart: on-failure

--- a/docker/httplaceholder-with-sqlite/docker-compose.yml
+++ b/docker/httplaceholder-with-sqlite/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     image: dukeofharen/httplaceholder:latest
     environment:
       sqliteConnectionString: 'Data Source=/etc/httplaceholder/httplaceholder.db'
+      verbose: 'true'
     ports:
       - 5000:5000
     restart: on-failure

--- a/docker/httplaceholder-with-stub-files/docker-compose.yml
+++ b/docker/httplaceholder-with-stub-files/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     environment:
       inputFile: '/etc/httplaceholder'
       useInMemoryStorage: 'true'
+      verbose: 'true'
     ports:
       - 5000:5000
     restart: on-failure

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -1687,7 +1687,7 @@ This paragraph contains all command line arguments supported by HttPlaceholder. 
 
 ### Verbose output
 
-If you want some more logging, append `-V` or `--verbose` as argument.
+If you want some more logging, append `-V` or `--verbose` as argument. You can also set environment value `verbose` to `true` to enable verbose logging.
 
 ```bash
 httplaceholder --verbose

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -213,13 +213,7 @@ The Docker container uses the configuration values as specified [here](#configur
 
 ### Docker Compose examples
 
-In the links below, you'll find several hosting scenario's written for Docker Compose. If you want to run any of these examples on your PC, open your terminal, go to one of the folders that contain a `docker-compose.yml` example and run `docker-compose up`.
-
-- [Hosting with file storage](https://github.com/dukeofharen/httplaceholder/tree/master/docker/httplaceholder-with-file-storage)
-- [Hosting with SQL Server](https://github.com/dukeofharen/httplaceholder/tree/master/docker/httplaceholder-with-mssql)
-- [Hosting with MySQL](https://github.com/dukeofharen/httplaceholder/tree/master/docker/httplaceholder-with-mysql)
-- [Hosting with SQLite](https://github.com/dukeofharen/httplaceholder/tree/master/docker/httplaceholder-with-sqlite)
-- [Hosting with .yml stub files](https://github.com/dukeofharen/httplaceholder/tree/master/docker/httplaceholder-with-stub-files)
+[Here](https://github.com/dukeofharen/httplaceholder/tree/master/docker) you can find a few Docker Compose examples how you can run HttPlaceholder using Docker.
 
 ## Hosting
 

--- a/src/HttPlaceholder/Resources/ManPage.resx
+++ b/src/HttPlaceholder/Resources/ManPage.resx
@@ -28,7 +28,8 @@
     </data>
     <data name="ExplanationHeader" xml:space="preserve">
         <value>Run this application with argument '-h' or '--help' to get more info about the command line arguments.
-When running in to trouble, or just see what's going on, run this application with argument '-V' or '--verbose' to print the configuration variables.</value>
+When running in to trouble, or just see what's going on, run this application with argument '-V' or '--verbose' to print the configuration variables.
+You can also set the "verbose" environment variable (without quotes) to "true" to enable verbose logging.</value>
     </data>
     <data name="ExceptionThrown" xml:space="preserve">
         <value>Unexpected exception thrown: {0}</value>

--- a/src/HttPlaceholder/Utilities/ProgramUtilities.cs
+++ b/src/HttPlaceholder/Utilities/ProgramUtilities.cs
@@ -18,14 +18,17 @@ namespace HttPlaceholder.Utilities
 {
     public static class ProgramUtilities
     {
-        private static readonly string[] _verboseArgs = {"-V", "--verbose"};
-        private static readonly string[] _versionArgs = {"-v", "--version"};
-        private static readonly string[] _helpArgs = {"-h", "--help", "-?"};
+        private static readonly string[] _verboseArgs = { "-V", "--verbose" };
+        private static readonly string[] _versionArgs = { "-v", "--version" };
+        private static readonly string[] _helpArgs = { "-h", "--help", "-?" };
 
         public static void ConfigureLogging(IEnumerable<string> args)
         {
+            var env = Environment.GetEnvironmentVariable("verbose");
+            var verbose = args.Any(_verboseArgs.Contains) ||
+                          string.Equals(env, "true", StringComparison.OrdinalIgnoreCase);
             var loggingConfig = new LoggerConfiguration();
-            loggingConfig = args.Any(_verboseArgs.Contains)
+            loggingConfig = verbose
                 ? loggingConfig.MinimumLevel.Debug()
                 : loggingConfig.MinimumLevel.Warning();
             Log.Logger = loggingConfig

--- a/src/HttPlaceholder/Utilities/ProgramUtilities.cs
+++ b/src/HttPlaceholder/Utilities/ProgramUtilities.cs
@@ -122,6 +122,9 @@ namespace HttPlaceholder.Utilities
         private static string GetManPage()
         {
             var builder = new StringBuilder();
+            builder.AppendLine(ManPage.ExplanationHeader);
+            builder.AppendLine();
+
             foreach (var constant in ConfigurationParser.GetConfigKeyMetadata())
             {
                 builder.AppendLine($"--{constant.Key}: {constant.Description} (e.g. {constant.Example})");


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

- By default, the HttPlaceholder will not have verbose logging enabled.
- Verbose logging can be enabled when providing `-V` or `--verbose` (which was already the case) OR by providing a `verbose` environment value with value `true`.

## Does this introduce a breaking change?

- [X] Yes
- [ ] No

Like said before, the verbose logging is turned off by default for the HttPlaceholder Docker image. If you relied on the verbose logging, you have to provide the `verbose` environment value with value `true` now.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
