### PR TITLE
Refactoring/fix cleaning of old requests

### DIFF
--- a/scripts/dev/docker-compose.yml
+++ b/scripts/dev/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3.8'
+services:
+  mysql:
+    image: mysql:5
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: httplaceholder
+      MYSQL_USER: httplaceholder
+      MYSQL_PASSWORD: httplaceholder
+    ports:
+      - 3306:3306
+    volumes:
+      - mysql5_data:/var/lib/mysql
+  mssql:
+    image: mcr.microsoft.com/mssql/server:2019-latest
+    environment:
+      ACCEPT_EULA: Y
+      SA_PASSWORD: Password123!
+      MSSQL_PID: Developer
+    ports:
+      - 1433:1433
+    volumes:
+      - mssql_data:/var/opt/mssql
+      - ./mssql_initscripts:/usr/local/bin/initscripts
+    command: /bin/bash /usr/local/bin/initscripts/entrypoint.sh
+
+volumes:
+  mysql5_data:
+  mssql_data:

--- a/scripts/dev/mssql_initscripts/create-db.sql
+++ b/scripts/dev/mssql_initscripts/create-db.sql
@@ -1,0 +1,2 @@
+CREATE DATABASE httplaceholder;
+GO

--- a/scripts/dev/mssql_initscripts/entrypoint.sh
+++ b/scripts/dev/mssql_initscripts/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Idea from https://www.softwaredeveloper.blog/initialize-mssql-in-docker-container
+/bin/bash /usr/local/bin/initscripts/initialize.sh & /opt/mssql/bin/sqlservr

--- a/scripts/dev/mssql_initscripts/initialize.sh
+++ b/scripts/dev/mssql_initscripts/initialize.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+sleep 20s
+echo "Initializing httplaceholder database"
+/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P $SA_PASSWORD -d master -i /usr/local/bin/initscripts/create-db.sql

--- a/scripts/dev/start-devenv.sh
+++ b/scripts/dev/start-devenv.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+sudo docker-compose -f "$DIR/docker-compose.yml" up

--- a/src/.run/Start devenv.run.xml
+++ b/src/.run/Start devenv.run.xml
@@ -1,0 +1,17 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Start devenv" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/../scripts/dev/start-devenv.sh" />
+    <option name="SCRIPT_OPTIONS" value="" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$/../scripts/dev" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/usr/bin/zsh" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
+    <option name="EXECUTE_SCRIPT_FILE" value="true" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/src/HttPlaceholder.Persistence/Implementations/StubSources/FileSystemStubSource.cs
+++ b/src/HttPlaceholder.Persistence/Implementations/StubSources/FileSystemStubSource.cs
@@ -141,7 +141,7 @@ namespace HttPlaceholder.Persistence.Implementations.StubSources
             .Select(s => new StubOverviewModel { Id = s.Id, Tenant = s.Tenant, Enabled = s.Enabled })
             .ToArray();
 
-        public async Task CleanOldRequestResultsAsync()
+        public Task CleanOldRequestResultsAsync()
         {
             // TODO make this thread safe. What if multiple instances of HttPlaceholder are running?
             var path = GetRequestsFolder();
@@ -155,6 +155,8 @@ namespace HttPlaceholder.Persistence.Implementations.StubSources
             {
                 _fileService.DeleteFile(filePath.path);
             }
+
+            return Task.CompletedTask;
         }
 
         public Task PrepareStubSourceAsync()


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

The deletion of old requests when using file storage is now done based on the "last write date time" on the file system. In the old situation, all requests were fetched and deserialized before the old ones were deleted, which is of course very inefficient.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
