### PR TITLE
Fixes with read-only stubs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 [1.4.1]
 - Added license and logo to Nuget packages (https://github.com/dukeofharen/httplaceholder/issues/76 and https://github.com/dukeofharen/httplaceholder/issues/81).
 - Added documentation to all classes of .NET client and HttPlaceholder (https://github.com/dukeofharen/httplaceholder/pull/213).
+- When setting the scenario with an empty state; set the scenario state to the default state of "Start" (https://github.com/dukeofharen/httplaceholder/pull/214).
+- Added icon at stub when stub is read-only.
 
 [1.4.0]
 - Use Roboto Mono as font for user interface.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@
 - Added license and logo to Nuget packages (https://github.com/dukeofharen/httplaceholder/issues/76 and https://github.com/dukeofharen/httplaceholder/issues/81).
 - Added documentation to all classes of .NET client and HttPlaceholder (https://github.com/dukeofharen/httplaceholder/pull/213).
 - When setting the scenario with an empty state; set the scenario state to the default state of "Start" (https://github.com/dukeofharen/httplaceholder/pull/214).
-- Added icon at stub when stub is read-only.
+- Added icon at stub when stub is read-only (https://github.com/dukeofharen/httplaceholder/pull/215).
 
 [1.4.0]
 - Use Roboto Mono as font for user interface.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,8 @@
 - Added documentation to all classes of .NET client and HttPlaceholder (https://github.com/dukeofharen/httplaceholder/pull/213).
 - When setting the scenario with an empty state; set the scenario state to the default state of "Start" (https://github.com/dukeofharen/httplaceholder/pull/214).
 - Added icon at stub when stub is read-only (https://github.com/dukeofharen/httplaceholder/pull/215).
+- When updating stub, make sure no read-only stub exists with the same ID (https://github.com/dukeofharen/httplaceholder/pull/215).
+- Updated UI so the "Disable stubs", "Enable stubs" and "Delete stubs" do not work with "read-only" stubs (https://github.com/dukeofharen/httplaceholder/pull/215).
 
 [1.4.0]
 - Use Roboto Mono as font for user interface.

--- a/gui/src/components/stub/Stub.vue
+++ b/gui/src/components/stub/Stub.vue
@@ -5,6 +5,9 @@
         {{ id }}
       </span>
       <span v-if="!enabled" class="disabled">&nbsp;(disabled)</span>
+      <span v-if="overviewStub.metadata.readOnly" title="Stub is read-only"
+        >&nbsp;<i class="bi-eye"></i
+      ></span>
     </template>
     <template v-slot:accordion-body>
       <div v-if="fullStub">

--- a/gui/src/views/Stubs.vue
+++ b/gui/src/views/Stubs.vue
@@ -211,7 +211,12 @@ export default {
 
     // Computed
     const filteredStubs = computed(() => filterStubs(stubs.value));
-    const disableMutationButtons = computed(() => !filteredStubs.value.length);
+    const filteredNonReadOnlyStubs = computed(() =>
+      filteredStubs.value.filter((s) => !s.metadata.readOnly)
+    );
+    const disableMutationButtons = computed(
+      () => !filteredNonReadOnlyStubs.value.length
+    );
 
     // Methods
     const loadStubs = async () => {
@@ -252,7 +257,7 @@ export default {
           handleHttpError(e);
         }
       };
-      const stubIds = filteredStubs.value.map((fs) => fs.stub.id);
+      const stubIds = filteredNonReadOnlyStubs.value.map((fs) => fs.stub.id);
       const promises = [];
       for (const stubId of stubIds) {
         promises.push(disableStub(stubId));
@@ -270,7 +275,7 @@ export default {
           handleHttpError(e);
         }
       };
-      const stubIds = filteredStubs.value.map((fs) => fs.stub.id);
+      const stubIds = filteredNonReadOnlyStubs.value.map((fs) => fs.stub.id);
       const promises = [];
       for (const stubId of stubIds) {
         promises.push(enableStub(stubId));
@@ -288,7 +293,7 @@ export default {
           handleHttpError(e);
         }
       };
-      const stubIds = filteredStubs.value.map((fs) => fs.stub.id);
+      const stubIds = filteredNonReadOnlyStubs.value.map((fs) => fs.stub.id);
       const promises = [];
       for (const stubId of stubIds) {
         promises.push(deleteStub(stubId));
@@ -339,6 +344,7 @@ export default {
       showDeleteStubsModal,
       deleteStubs,
       disableMutationButtons,
+      filteredNonReadOnlyStubs,
     };
   },
 };

--- a/src/HttPlaceholder.Application.Tests/Stubs/Commands/UpdateStubCommandHandlerFacts.cs
+++ b/src/HttPlaceholder.Application.Tests/Stubs/Commands/UpdateStubCommandHandlerFacts.cs
@@ -8,71 +8,110 @@ using HttPlaceholder.Application.Stubs.Commands.UpdateStubCommand;
 using HttPlaceholder.Domain;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using Moq.AutoMock;
 
 namespace HttPlaceholder.Application.Tests.Stubs.Commands;
 
 [TestClass]
 public class UpdateStubCommandHandlerFacts
 {
-    private readonly Mock<IStubContext> _mockStubContext = new();
-    private readonly Mock<IStubModelValidator> _mockStubModelValidator = new();
-    private UpdateStubCommandHandler _handler;
-
-    [TestInitialize]
-    public void Initialize() =>
-        _handler = new UpdateStubCommandHandler(_mockStubContext.Object, _mockStubModelValidator.Object);
+    private readonly AutoMocker _mocker = new();
 
     [TestCleanup]
-    public void Cleanup()
-    {
-        _mockStubContext.VerifyAll();
-        _mockStubModelValidator.VerifyAll();
-    }
+    public void Cleanup() => _mocker.VerifyAll();
 
     [TestMethod]
     public async Task Handle_HasValidationErrors_ShouldThrowValidationException()
     {
         // Arrange
+        var mockStubModelValidator = _mocker.GetMock<IStubModelValidator>();
+        var mockStubContext = _mocker.GetMock<IStubContext>();
+        var handler = _mocker.CreateInstance<UpdateStubCommandHandler>();
+
         var stub = new StubModel {Id = "stub1"};
         var request = new UpdateStubCommand("new-stub-id", stub);
 
         var errors = new[] {"error1"};
 
-        _mockStubModelValidator
+        mockStubModelValidator
             .Setup(m => m.ValidateStubModel(stub))
             .Returns(errors);
 
         // Act
         var exception =
             await Assert.ThrowsExceptionAsync<ValidationException>(() =>
-                _handler.Handle(request, CancellationToken.None));
+                handler.Handle(request, CancellationToken.None));
 
         // Assert
         Assert.AreEqual(errors.Single(), exception.ValidationErrors.Single());
-        _mockStubContext.Verify(m => m.DeleteStubAsync(stub.Id), Times.Never);
-        _mockStubContext.Verify(m => m.DeleteStubAsync(request.StubId), Times.Never);
-        _mockStubContext.Verify(m => m.AddStubAsync(stub), Times.Never);
+        mockStubContext.Verify(m => m.DeleteStubAsync(stub.Id), Times.Never);
+        mockStubContext.Verify(m => m.DeleteStubAsync(request.StubId), Times.Never);
+        mockStubContext.Verify(m => m.AddStubAsync(stub), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task Handle_StubIsReadonly_ShouldThrowValidationException()
+    {
+        // Arrange
+        var mockStubModelValidator = _mocker.GetMock<IStubModelValidator>();
+        var mockStubContext = _mocker.GetMock<IStubContext>();
+        var handler = _mocker.CreateInstance<UpdateStubCommandHandler>();
+
+        var stub = new StubModel {Id = "stub1"};
+        var request = new UpdateStubCommand("new-stub-id", stub);
+
+        mockStubModelValidator
+            .Setup(m => m.ValidateStubModel(stub))
+            .Returns(Array.Empty<string>());
+
+        var existingStub = new FullStubModel
+        {
+            Stub = new StubModel(), Metadata = new StubMetadataModel {ReadOnly = true}
+        };
+        mockStubContext
+            .Setup(m => m.GetStubAsync(stub.Id))
+            .ReturnsAsync(existingStub);
+
+        // Act
+        var exception =
+            await Assert.ThrowsExceptionAsync<ValidationException>(() =>
+                handler.Handle(request, CancellationToken.None));
+
+        // Assert
+        var errors = exception.ValidationErrors.ToArray();
+        Assert.AreEqual(1, errors.Length);
+        Assert.AreEqual("Stub with ID 'stub1' is read-only; it can not be updated through the API.", errors.Single());
     }
 
     [TestMethod]
     public async Task Handle_NoValidationErrors_ShouldUpdateStub()
     {
         // Arrange
+        var mockStubModelValidator = _mocker.GetMock<IStubModelValidator>();
+        var mockStubContext = _mocker.GetMock<IStubContext>();
+        var handler = _mocker.CreateInstance<UpdateStubCommandHandler>();
+
         var stub = new StubModel {Id = "stub1"};
         var request = new UpdateStubCommand("new-stub-id", stub);
 
-        var errors = Array.Empty<string>();
-
-        _mockStubModelValidator
+        mockStubModelValidator
             .Setup(m => m.ValidateStubModel(stub))
-            .Returns(errors);
+            .Returns(Array.Empty<string>());
+
+        var existingStub = new FullStubModel
+        {
+            Stub = new StubModel(), Metadata = new StubMetadataModel {ReadOnly = false}
+        };
+        mockStubContext
+            .Setup(m => m.GetStubAsync(stub.Id))
+            .ReturnsAsync(existingStub);
 
         // Act
-        await _handler.Handle(request, CancellationToken.None);
+        await handler.Handle(request, CancellationToken.None);
 
         // Assert
-        _mockStubContext.Verify(m => m.DeleteStubAsync(stub.Id), Times.Once);
-        _mockStubContext.Verify(m => m.DeleteStubAsync(request.StubId), Times.Once);
-        _mockStubContext.Verify(m => m.AddStubAsync(stub), Times.Once);
+        mockStubContext.Verify(m => m.DeleteStubAsync(stub.Id), Times.Once);
+        mockStubContext.Verify(m => m.DeleteStubAsync(request.StubId), Times.Once);
+        mockStubContext.Verify(m => m.AddStubAsync(stub), Times.Once);
     }
 }

--- a/src/HttPlaceholder.Application/Stubs/Commands/UpdateStubCommand/UpdateStubCommandHandler.cs
+++ b/src/HttPlaceholder.Application/Stubs/Commands/UpdateStubCommand/UpdateStubCommandHandler.cs
@@ -33,6 +33,20 @@ public class UpdateStubCommandHandler : IRequestHandler<UpdateStubCommand>
             throw new ValidationException(validationResults);
         }
 
+        // Check that the stub is not read-only.
+        const string exceptionFormat = "Stub with ID '{0}' is read-only; it can not be updated through the API.";
+        var oldStub = await _stubContext.GetStubAsync(request.StubId);
+        if (oldStub?.Metadata?.ReadOnly == true)
+        {
+            throw new ValidationException(string.Format(exceptionFormat, request.StubId));
+        }
+
+        var newStub = await _stubContext.GetStubAsync(request.Stub.Id);
+        if (newStub?.Metadata?.ReadOnly == true)
+        {
+            throw new ValidationException(string.Format(exceptionFormat, request.Stub.Id));
+        }
+
         // Delete stub with same ID.
         await _stubContext.DeleteStubAsync(request.StubId);
         await _stubContext.DeleteStubAsync(request.Stub.Id);


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
- Added icon at stub when stub is read-only.
- When updating stub, make sure no read-only stub exists with the same ID.
- Updated UI so the "Disable stubs", "Enable stubs" and "Delete stubs" do not work with "read-only" stubs.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
