### PR TITLE
Feature/216 old requests scheduled job

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,9 @@
     - This configuration parameter has been added because some people host HttPlaceholder in a cloud environment with a serverless database. Performing a query every 5 minutes can crank up the costs. By cleaning the requests in the old way, no more SQL queries than necessary will be performed so the costs stay (relatively) low.
     - Besides this, whenever a request could not be matched to a stub and the user interface is disable, an empty response will be returned instead of a basic HTML page.
 
+# BREAKING CHANGES
+- As mentioned before, the "clean old requests" job is now enabled by default. If you want HttPlaceholder to continue cleaning requests in the old way, set `cleanOldRequestsInBackgroundJob` to `false` to not get a bigger bill on your serverless database than needed.
+
 [1.4.0]
 - Use Roboto Mono as font for user interface.
 - Fixed bug in tenant filtering of requests and stubs screen.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,11 @@
 - Added icon at stub when stub is read-only (https://github.com/dukeofharen/httplaceholder/pull/215).
 - When updating stub, make sure no read-only stub exists with the same ID (https://github.com/dukeofharen/httplaceholder/pull/215).
 - Updated UI so the "Disable stubs", "Enable stubs" and "Delete stubs" do not work with "read-only" stubs (https://github.com/dukeofharen/httplaceholder/pull/215).
+- Created a scheduled job that is used for cleaning old requests (https://github.com/dukeofharen/httplaceholder/issues/216).
+    - By default, this job is enabled. This means that the old requests will be cleaned once in every 5 minutes. When this job is enabled, the cleaning of requests does not occur anymore after any stub request.
+    - This job can, however, be turned off. Configuration parameter `cleanOldRequestsInBackgroundJob` has been added for this purpose.
+    - This configuration parameter has been added because some people host HttPlaceholder in a cloud environment with a serverless database. Performing a query every 5 minutes can crank up the costs. By cleaning the requests in the old way, no more SQL queries than necessary will be performed so the costs stay (relatively) low.
+    - Besides this, whenever a request could not be matched to a stub and the user interface is disable, an empty response will be returned instead of a basic HTML page.
 
 [1.4.0]
 - Use Roboto Mono as font for user interface.

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -1704,7 +1704,11 @@ The import collection is used to be able to import all kinds of data in HttPlace
 
 This paragraph contains all command line arguments supported by HttPlaceholder. Configuration can be set using command line arguments, a configuration file or environment variables.
 
-## Command line arguments
+## Configuration properties
+
+### Environment variables
+
+You can set any of the configuration properties as environment variable. E.g. when you want to set the HTTPS port as environment variable, you can set an environment variable with the name `httpsPort` and set it to for example value `4433`.
 
 ### Verbose output
 

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -1654,7 +1654,7 @@ Finally, there is also a reverse proxy setting called `replaceRootUrl` (which is
 
 # REST API
 
-Like many other automation and development tools, HttPlaceholder has a REST API that you can use to automate the creation of stubs. By default, the stubs and requests are stored in the `.httplaceholder` folder of the current logged in user (you can change this behavior; see [config](#configuration)). The REST API gives you access to the following collections: the stubs collection, the requests collection (to see all requests that are made to HttPlaceholder), users collection, tenants collection, scenario collection, import collection and users collection.
+Like many other automation and development tools, HttPlaceholder has a REST API that you can use to automate the creation of stubs. By default, the stubs and requests are stored in the `.httplaceholder` folder of the current logged in user (you can change this behavior; see [config](#configuration)). The REST API gives you access to the following collections: the stubs collection, the requests collection (to see all requests that are made to HttPlaceholder), users collection, tenants collection, scenario collection, scheduled job collection, import collection and users collection.
 
 Click [here](https://github.com/dukeofharen/httplaceholder/releases/latest) if you want the swagger.json file. Using this swagger.json file, you can easily create a REST client for your favourite programming language (e.g. using a tool like [autorest](https://github.com/Azure/autorest)).
 
@@ -1699,6 +1699,10 @@ The import collection is used to be able to import all kinds of data in HttPlace
 * [cURL commands](#import-curl-commands)
 * [HTTP Archive (HAR)](#import-http-archive-har)
 * [OpenAPI definitions](#import-openapi-definition)
+
+## Scheduled jobs
+
+The scheduled jobs collection is used for calling scheduled jobs manually. This is mainly for testing purposes, because the scheduled jobs, as the name says, are run on a schedule in the background.
 
 # Configuration
 
@@ -1839,6 +1843,16 @@ httplaceholder --oldRequestsQueueLength 100
 ```
 
 The maximum number of HTTP requests that the in memory stub source (used for the REST API) should store before truncating old records. Default: 40.
+
+### Run the cleaning of requests in the background
+
+```bash
+httplaceholder --cleanOldRequestsInBackgroundJob
+```
+
+Whether the cleaning of old requests should be performed in a background job. If this configuration value is turned on, old requests will be cleaned once in 5 minutes. If this configuration value is turned off, the deletion of old requests is done after every non-API request.
+
+The "old way" of cleaning old requests was not deleted because running the scheduled job every 5 minutes might mean a call to the database, even though no requests need to be cleaned. For people running HttPlaceholder with a serverless database, it means paying extra costs, so deleting the requests after every non-API request is the cheaper way to go.
 
 ### REST API Authentication (optional)
 

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -1854,6 +1854,8 @@ Whether the cleaning of old requests should be performed in a background job. If
 
 The "old way" of cleaning old requests was not deleted because running the scheduled job every 5 minutes might mean a call to the database, even though no requests need to be cleaned. For people running HttPlaceholder with a serverless database, it means paying extra costs, so deleting the requests after every non-API request is the cheaper way to go.
 
+Also, take a look at [here](#request-logging-optional) for more information.
+
 ### REST API Authentication (optional)
 
 ```bash

--- a/docs/samples/requests.json
+++ b/docs/samples/requests.json
@@ -1988,6 +1988,54 @@
 					]
 				},
 				{
+					"name": "Scheduled jobs",
+					"item": [
+						{
+							"name": "Run CleanOldRequestsJob",
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "pass",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "user",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "text/yaml",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "id: test-situation\r\ntenant: 01-get\r\nconditions:\r\n  method: GET\r\n  url:\r\n    path: /testtesttest\r\n    query:\r\n      id: 12\r\nresponse:\r\n  statusCode: 200\r\n  text: OK my dude!"
+								},
+								"url": {
+									"raw": "{{rootUrl}}ph-api/scheduledJob/CleanOldRequestsJob",
+									"host": [
+										"{{rootUrl}}ph-api"
+									],
+									"path": [
+										"scheduledJob",
+										"CleanOldRequestsJob"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
 					"name": "Stubs",
 					"item": [
 						{

--- a/docs/samples/requests.json
+++ b/docs/samples/requests.json
@@ -2032,6 +2032,51 @@
 								}
 							},
 							"response": []
+						},
+						{
+							"name": "Get scheduled job names",
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "pass",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "user",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "text/yaml",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "id: test-situation\r\ntenant: 01-get\r\nconditions:\r\n  method: GET\r\n  url:\r\n    path: /testtesttest\r\n    query:\r\n      id: 12\r\nresponse:\r\n  statusCode: 200\r\n  text: OK my dude!"
+								},
+								"url": {
+									"raw": "{{rootUrl}}ph-api/scheduledJob",
+									"host": [
+										"{{rootUrl}}ph-api"
+									],
+									"path": [
+										"scheduledJob"
+									]
+								}
+							},
+							"response": []
 						}
 					]
 				},

--- a/src/HttPlaceholder.Application/Configuration/ConfigKeys.cs
+++ b/src/HttPlaceholder.Application/Configuration/ConfigKeys.cs
@@ -55,6 +55,16 @@ public static class ConfigKeys
     public const string OldRequestsQueueLengthKey = "oldRequestsQueueLength";
 
     /// <summary>
+    /// Constant for cleanOldRequestsInBackgroundJob.
+    /// </summary>
+    [ConfigKey(
+        Description = "whether the cleaning of old requests should be done in a background job. If set to true, will delete old requests in a background job that runs once in 5 minutes. If set to false, will clean old requests every time a request is handled. Default: true.",
+        Example = "true",
+        IsBoolValue = true,
+        ConfigPath = "Storage:CleanOldRequestsInBackgroundJob")]
+    public const string CleanOldRequestsInBackgroundJob = "cleanOldRequestsInBackgroundJob";
+
+    /// <summary>
     /// Constant for pfxPassword.
     /// </summary>
     [ConfigKey(

--- a/src/HttPlaceholder.Application/Configuration/StorageSettingsModel.cs
+++ b/src/HttPlaceholder.Application/Configuration/StorageSettingsModel.cs
@@ -29,4 +29,9 @@ public class StorageSettingsModel
     /// Gets or sets whether everything should be stored in memory.
     /// </summary>
     public bool UseInMemoryStorage { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the deletion of old requests should be done in a background job.
+    /// </summary>
+    public bool CleanOldRequestsInBackgroundJob { get; set; }
 }

--- a/src/HttPlaceholder.Application/StubExecution/IStubContext.cs
+++ b/src/HttPlaceholder.Application/StubExecution/IStubContext.cs
@@ -118,6 +118,11 @@ public interface IStubContext
     Task<bool> DeleteRequestAsync(string correlationId);
 
     /// <summary>
+    /// Clean all old requests.
+    /// </summary>
+    Task CleanOldRequestResultsAsync();
+
+    /// <summary>
     /// Retrieves a list with all tenant names.
     /// </summary>
     /// <returns>A list with all tenant names.</returns>

--- a/src/HttPlaceholder.Client.Examples/Program.cs
+++ b/src/HttPlaceholder.Client.Examples/Program.cs
@@ -178,6 +178,12 @@ curl 'https://site.com/_nuxt/1d6c3a9.js' \
             // Create stubs based on OpenAPI definition.
             var openapi = await File.ReadAllTextAsync("petstore.yaml");
             var openApiResult = await client.CreateOpenApiStubsAsync(openapi, false);
+
+            // Execute a scheduled job.
+            var scheduledJobResult = await client.ExecuteScheduledJobAsync("CleanOldRequestsJob");
+
+            // Get a list of scheduled job names.
+            var scheduledJobNames = await client.GetScheduledJobNamesAsync();
         }
         catch (Exception ex)
         {

--- a/src/HttPlaceholder.Client.Tests/HttPlaceholderClientFacts/ExecuteScheduledJobFacts.cs
+++ b/src/HttPlaceholder.Client.Tests/HttPlaceholderClientFacts/ExecuteScheduledJobFacts.cs
@@ -1,0 +1,51 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using HttPlaceholder.Client.Exceptions;
+using HttPlaceholder.Client.Implementations;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RichardSzalay.MockHttp;
+
+namespace HttPlaceholder.Client.Tests.HttPlaceholderClientFacts;
+
+[TestClass]
+public class ExecuteScheduledJobFacts : BaseClientTest
+{
+    private const string ExecuteJobJson = @"{
+    ""message"": ""OK""
+}";
+
+    [TestMethod]
+    public async Task ExecuteScheduledJobAsync_ExceptionInRequest_ShouldThrowHttPlaceholderClientException()
+    {
+        // Arrange
+        const string jobName = "CleanOldRequestsJobs";
+        var client = new HttPlaceholderClient(CreateHttpClient(mock => mock
+            .When(HttpMethod.Post, $"{BaseUrl}ph-api/scheduledJob/{jobName}")
+            .Respond(HttpStatusCode.BadRequest, "text/plain", "Error occurred!")));
+
+        // Act
+        var exception =
+            await Assert.ThrowsExceptionAsync<HttPlaceholderClientException>(() => client.ExecuteScheduledJobAsync(jobName));
+
+        // Assert
+        Assert.AreEqual("Status code '400' returned by HttPlaceholder with message 'Error occurred!'",
+            exception.Message);
+    }
+
+    [TestMethod]
+    public async Task ExecuteScheduledJobAsync_ShouldExecuteScheduledJob()
+    {
+        // Arrange
+        const string jobName = "CleanOldRequestsJobs";
+        var client = new HttPlaceholderClient(CreateHttpClient(mock => mock
+            .When(HttpMethod.Post, $"{BaseUrl}ph-api/scheduledJob/{jobName}")
+            .Respond("application/json", ExecuteJobJson)));
+
+        // Act
+        var result = await client.ExecuteScheduledJobAsync(jobName);
+
+        // Assert
+        Assert.AreEqual("OK", result.Message);
+    }
+}

--- a/src/HttPlaceholder.Client.Tests/HttPlaceholderClientFacts/GetScheduledJobNamesFacts.cs
+++ b/src/HttPlaceholder.Client.Tests/HttPlaceholderClientFacts/GetScheduledJobNamesFacts.cs
@@ -1,0 +1,48 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using HttPlaceholder.Client.Exceptions;
+using HttPlaceholder.Client.Implementations;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RichardSzalay.MockHttp;
+
+namespace HttPlaceholder.Client.Tests.HttPlaceholderClientFacts;
+
+[TestClass]
+public class GetScheduledJobNamesFacts : BaseClientTest
+{
+    private const string GetScheduledJobsJson = @"[""CleanOldRequestsJob""]";
+
+    [TestMethod]
+    public async Task ExecuteScheduledJobAsync_ExceptionInRequest_ShouldThrowHttPlaceholderClientException()
+    {
+        // Arrange
+        var client = new HttPlaceholderClient(CreateHttpClient(mock => mock
+            .When(HttpMethod.Get, $"{BaseUrl}ph-api/scheduledJob")
+            .Respond(HttpStatusCode.BadRequest, "text/plain", "Error occurred!")));
+
+        // Act
+        var exception =
+            await Assert.ThrowsExceptionAsync<HttPlaceholderClientException>(() => client.GetScheduledJobNamesAsync());
+
+        // Assert
+        Assert.AreEqual("Status code '400' returned by HttPlaceholder with message 'Error occurred!'",
+            exception.Message);
+    }
+
+    [TestMethod]
+    public async Task ExecuteScheduledJobAsync_ShouldExecuteScheduledJob()
+    {
+        // Arrange
+        var client = new HttPlaceholderClient(CreateHttpClient(mock => mock
+            .When(HttpMethod.Get, $"{BaseUrl}ph-api/scheduledJob")
+            .Respond("application/json", GetScheduledJobsJson)));
+
+        // Act
+        var result = await client.GetScheduledJobNamesAsync();
+
+        // Assert
+        Assert.AreEqual(1, result.Length);
+        Assert.AreEqual("CleanOldRequestsJob", result[0]);
+    }
+}

--- a/src/HttPlaceholder.Client/Dto/ScheduledJobs/JobExecutionResultDto.cs
+++ b/src/HttPlaceholder.Client/Dto/ScheduledJobs/JobExecutionResultDto.cs
@@ -1,0 +1,20 @@
+﻿namespace HttPlaceholder.Client.Dto.ScheduledJobs;
+
+/// <summary>
+/// A model that is returned when a scheduled job has executed through the API.
+/// </summary>
+public class JobExecutionResultDto
+{
+    /// <summary>
+    /// Constructs a <see cref="JobExecutionResultDto"/> instance.
+    /// </summary>
+    public JobExecutionResultDto(string message)
+    {
+        Message = message;
+    }
+
+    /// <summary>
+    /// Gets or sets message.
+    /// </summary>
+    public string Message { get; }
+}

--- a/src/HttPlaceholder.Client/IHttPlaceholderClient.cs
+++ b/src/HttPlaceholder.Client/IHttPlaceholderClient.cs
@@ -4,6 +4,7 @@ using HttPlaceholder.Client.Dto.Enums;
 using HttPlaceholder.Client.Dto.Metadata;
 using HttPlaceholder.Client.Dto.Requests;
 using HttPlaceholder.Client.Dto.Scenarios;
+using HttPlaceholder.Client.Dto.ScheduledJobs;
 using HttPlaceholder.Client.Dto.Stubs;
 using HttPlaceholder.Client.Dto.Users;
 using HttPlaceholder.Client.StubBuilders;
@@ -256,5 +257,18 @@ namespace HttPlaceholder.Client
         /// <param name="tenant">The tenant (category) the stubs should be added under. If no tenant is provided, a tenant name will be generated.</param>
         /// <returns>The created stubs.</returns>
         Task<IEnumerable<FullStubDto>> CreateOpenApiStubsAsync(string input, bool doNotCreateStub, string tenant = "");
+
+        /// <summary>
+        /// Executes a given scheduled job.
+        /// </summary>
+        /// <param name="jobName">The name of the job.</param>
+        /// <returns>A <see cref="JobExecutionResultDto"/> with the execution results.</returns>
+        Task<JobExecutionResultDto> ExecuteScheduledJobAsync(string jobName);
+
+        /// <summary>
+        /// Gets a list of scheduled job names.
+        /// </summary>
+        /// <returns>An array containing all active scheduled job names.</returns>
+        Task<string[]> GetScheduledJobNamesAsync();
     }
 }

--- a/src/HttPlaceholder.Client/Implementations/HttPlaceholderClient.cs
+++ b/src/HttPlaceholder.Client/Implementations/HttPlaceholderClient.cs
@@ -7,6 +7,7 @@ using HttPlaceholder.Client.Dto.Enums;
 using HttPlaceholder.Client.Dto.Metadata;
 using HttPlaceholder.Client.Dto.Requests;
 using HttPlaceholder.Client.Dto.Scenarios;
+using HttPlaceholder.Client.Dto.ScheduledJobs;
 using HttPlaceholder.Client.Dto.Stubs;
 using HttPlaceholder.Client.Dto.Users;
 using HttPlaceholder.Client.Exceptions;
@@ -495,6 +496,33 @@ namespace HttPlaceholder.Client.Implementations
             }
 
             return JsonConvert.DeserializeObject<IEnumerable<FullStubDto>>(content);
+        }
+
+        /// <inheritdoc />
+        public async Task<JobExecutionResultDto> ExecuteScheduledJobAsync(string jobName)
+        {
+            using var response = await HttpClient.PostAsync(
+                $"/ph-api/scheduledJob/{jobName}", new StringContent(string.Empty));
+            var content = await response.Content.ReadAsStringAsync();
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new HttPlaceholderClientException(response.StatusCode, content);
+            }
+
+            return JsonConvert.DeserializeObject<JobExecutionResultDto>(content);
+        }
+
+        /// <inheritdoc />
+        public async Task<string[]> GetScheduledJobNamesAsync()
+        {
+            using var response = await HttpClient.GetAsync($"/ph-api/scheduledJob");
+            var content = await response.Content.ReadAsStringAsync();
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new HttPlaceholderClientException(response.StatusCode, content);
+            }
+
+            return JsonConvert.DeserializeObject<string[]>(content);
         }
     }
 }

--- a/src/HttPlaceholder.Common/IAsyncService.cs
+++ b/src/HttPlaceholder.Common/IAsyncService.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace HttPlaceholder.Common;
@@ -11,6 +12,12 @@ public interface IAsyncService
     /// Starts a delay.
     /// </summary>
     /// <param name="millis">The number of milliseconds to wait.</param>
-    /// <returns>A task.</returns>
     Task DelayAsync(int millis);
+
+    /// <summary>
+    /// Starts a delay.
+    /// </summary>
+    /// <param name="millis">The number of milliseconds to wait.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task DelayAsync(int millis, CancellationToken cancellationToken);
 }

--- a/src/HttPlaceholder.Domain/Constants.cs
+++ b/src/HttPlaceholder.Domain/Constants.cs
@@ -63,6 +63,11 @@ public static class Constants
     public const int DefaultOldRequestsQueueLength = 40;
 
     /// <summary>
+    /// Whether the CleanOldRequests job is enabled by default.
+    /// </summary>
+    public const bool CleanOldRequestsInBackgroundJob = true;
+
+    /// <summary>
     /// The default maximum "extra duration" milliseconds.
     /// </summary>
     public const int DefaultMaximumExtraDuration = 60000;

--- a/src/HttPlaceholder.Infrastructure.Tests/Configuration/ConfigurationParserFacts.cs
+++ b/src/HttPlaceholder.Infrastructure.Tests/Configuration/ConfigurationParserFacts.cs
@@ -195,6 +195,7 @@ public class ConfigurationParserFacts
         Assert.AreEqual("True", result["Gui:EnableUserInterface"]);
         Assert.AreEqual("40", result["Storage:OldRequestsQueueLength"]);
         Assert.AreEqual("60000", result["Stub:MaximumExtraDurationMillis"]);
+        Assert.AreEqual("True", result["Storage:CleanOldRequestsInBackgroundJob"]);
     }
 
     [DataTestMethod]

--- a/src/HttPlaceholder.Infrastructure/Configuration/ConfigurationParser.cs
+++ b/src/HttPlaceholder.Infrastructure/Configuration/ConfigurationParser.cs
@@ -98,6 +98,7 @@ public class ConfigurationParser
         argsDictionary.EnsureEntryExists(ConfigKeys.EnableUserInterface, EnableUserInterface);
         argsDictionary.EnsureEntryExists(ConfigKeys.OldRequestsQueueLengthKey, DefaultOldRequestsQueueLength);
         argsDictionary.EnsureEntryExists(ConfigKeys.MaximumExtraDurationMillisKey, DefaultMaximumExtraDuration);
+        argsDictionary.EnsureEntryExists(ConfigKeys.CleanOldRequestsInBackgroundJob, CleanOldRequestsInBackgroundJob);
 
         // Determine and set file storage location.
         string fileStorageLocation = null;

--- a/src/HttPlaceholder.Infrastructure/Implementations/AsyncService.cs
+++ b/src/HttPlaceholder.Infrastructure/Implementations/AsyncService.cs
@@ -10,4 +10,8 @@ public class AsyncService : IAsyncService
     /// <inheritdoc />
     public async Task DelayAsync(int millis) =>
         await Task.Delay(millis);
+
+    /// <inheritdoc />
+    public async Task DelayAsync(int millis, CancellationToken cancellationToken) =>
+        await Task.Delay(millis, cancellationToken);
 }

--- a/src/HttPlaceholder.Persistence.Tests/Implementations/StubContextFacts.cs
+++ b/src/HttPlaceholder.Persistence.Tests/Implementations/StubContextFacts.cs
@@ -236,6 +236,20 @@ public class StubContextFacts
     }
 
     [TestMethod]
+    public async Task CleanOldRequestResultsAsync_HappyFlow()
+    {
+        // arrange
+        var stubSource = new Mock<IWritableStubSource>();
+        _stubSources.Add(stubSource.Object);
+
+        // act
+        await _context.CleanOldRequestResultsAsync();
+
+        // assert
+        stubSource.Verify(m => m.CleanOldRequestResultsAsync(), Times.Once);
+    }
+
+    [TestMethod]
     public async Task GetRequestResultsAsync_HappyFlow()
     {
         // arrange

--- a/src/HttPlaceholder.Persistence.Tests/Implementations/StubContextFacts.cs
+++ b/src/HttPlaceholder.Persistence.Tests/Implementations/StubContextFacts.cs
@@ -2,10 +2,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using HttPlaceholder.Application.Configuration;
 using HttPlaceholder.Application.Exceptions;
 using HttPlaceholder.Application.Interfaces.Persistence;
 using HttPlaceholder.Domain;
 using HttPlaceholder.Persistence.Implementations;
+using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 
@@ -15,10 +17,11 @@ namespace HttPlaceholder.Persistence.Tests.Implementations;
 public class StubContextFacts
 {
     private readonly IList<IStubSource> _stubSources = new List<IStubSource>();
+    private readonly SettingsModel _settings = new() {Storage = new StorageSettingsModel()};
     private StubContext _context;
 
     [TestInitialize]
-    public void Initialize() => _context = new StubContext(_stubSources);
+    public void Initialize() => _context = new StubContext(_stubSources, Options.Create(_settings));
 
     [TestMethod]
     public async Task GetStubsAsync_HappyFlow()
@@ -233,6 +236,34 @@ public class StubContextFacts
         stubSource.Verify(m => m.CleanOldRequestResultsAsync(), Times.Once);
 
         Assert.AreEqual(stub.Tenant, request.StubTenant);
+    }
+
+    [TestMethod]
+    public async Task AddRequestResultAsync_CleanOldRequestsJobEnabled_ShouldNotCallCleanOldRequestResultsAsync()
+    {
+        // arrange
+        _settings.Storage.CleanOldRequestsInBackgroundJob = true;
+
+        var stubSource = new Mock<IWritableStubSource>();
+
+        var stub = new StubModel {Id = "stub1", Tenant = "tenant1"};
+        stubSource
+            .Setup(m => m.GetStubAsync(stub.Id))
+            .ReturnsAsync(stub);
+
+        var request = new RequestResultModel {ExecutingStubId = stub.Id};
+        stubSource
+            .Setup(m => m.AddRequestResultAsync(request))
+            .Returns(Task.CompletedTask);
+
+        _stubSources.Add(stubSource.Object);
+
+        // act
+        await _context.AddRequestResultAsync(request);
+
+        // assert
+        stubSource.Verify(m => m.AddRequestResultAsync(request), Times.Once);
+        stubSource.Verify(m => m.CleanOldRequestResultsAsync(), Times.Never);
     }
 
     [TestMethod]

--- a/src/HttPlaceholder.Persistence/Implementations/StubContext.cs
+++ b/src/HttPlaceholder.Persistence/Implementations/StubContext.cs
@@ -200,6 +200,13 @@ internal class StubContext : IStubContext
     }
 
     /// <inheritdoc />
+    public async Task CleanOldRequestResultsAsync()
+    {
+        var source = GetWritableStubSource();
+        await source.CleanOldRequestResultsAsync();
+    }
+
+    /// <inheritdoc />
     public async Task<IEnumerable<string>> GetTenantNamesAsync() =>
         (await GetStubsAsync())
         .Select(s => s.Stub.Tenant)

--- a/src/HttPlaceholder.Persistence/Implementations/StubContext.cs
+++ b/src/HttPlaceholder.Persistence/Implementations/StubContext.cs
@@ -2,10 +2,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using HttPlaceholder.Application.Configuration;
 using HttPlaceholder.Application.Exceptions;
 using HttPlaceholder.Application.Interfaces.Persistence;
 using HttPlaceholder.Application.StubExecution;
 using HttPlaceholder.Domain;
+using Microsoft.Extensions.Options;
 
 namespace HttPlaceholder.Persistence.Implementations;
 
@@ -13,10 +15,12 @@ namespace HttPlaceholder.Persistence.Implementations;
 internal class StubContext : IStubContext
 {
     private readonly IEnumerable<IStubSource> _stubSources;
+    private readonly SettingsModel _settings;
 
-    public StubContext(IEnumerable<IStubSource> stubSources)
+    public StubContext(IEnumerable<IStubSource> stubSources, IOptions<SettingsModel> options)
     {
         _stubSources = stubSources;
+        _settings = options.Value;
     }
 
     /// <inheritdoc />
@@ -43,7 +47,7 @@ internal class StubContext : IStubContext
             var stubs = await source.GetStubsOverviewAsync();
             var fullStubModels = stubs.Select(s => new FullStubOverviewModel
             {
-                Stub = s, Metadata = new StubMetadataModel { ReadOnly = stubSourceIsReadOnly }
+                Stub = s, Metadata = new StubMetadataModel {ReadOnly = stubSourceIsReadOnly}
             });
             result.AddRange(fullStubModels);
         }
@@ -63,7 +67,7 @@ internal class StubContext : IStubContext
 
         var source = GetWritableStubSource();
         await source.AddStubAsync(stub);
-        return new FullStubModel { Stub = stub, Metadata = new StubMetadataModel { ReadOnly = false } };
+        return new FullStubModel {Stub = stub, Metadata = new StubMetadataModel {ReadOnly = false}};
     }
 
     /// <inheritdoc />
@@ -132,8 +136,7 @@ internal class StubContext : IStubContext
             {
                 result = new FullStubModel
                 {
-                    Stub = stub,
-                    Metadata = new StubMetadataModel { ReadOnly = source is not IWritableStubSource }
+                    Stub = stub, Metadata = new StubMetadataModel {ReadOnly = source is not IWritableStubSource}
                 };
                 break;
             }
@@ -147,8 +150,11 @@ internal class StubContext : IStubContext
     {
         var source = GetWritableStubSource();
 
-        // Clean up old requests here.
-        await source.CleanOldRequestResultsAsync();
+        if (_settings.Storage?.CleanOldRequestsInBackgroundJob == false)
+        {
+            // Clean up old requests here.
+            await source.CleanOldRequestResultsAsync();
+        }
 
         var stub = !string.IsNullOrWhiteSpace(requestResult.ExecutingStubId)
             ? await GetStubAsync(requestResult.ExecutingStubId)
@@ -239,7 +245,7 @@ internal class StubContext : IStubContext
             var stubs = await source.GetStubsAsync();
             var fullStubModels = stubs.Select(s => new FullStubModel
             {
-                Stub = s, Metadata = new StubMetadataModel { ReadOnly = stubSourceIsReadOnly }
+                Stub = s, Metadata = new StubMetadataModel {ReadOnly = stubSourceIsReadOnly}
             });
             result.AddRange(fullStubModels);
         }

--- a/src/HttPlaceholder.Tests/HostedServices/BackgroundServiceFacts.cs
+++ b/src/HttPlaceholder.Tests/HostedServices/BackgroundServiceFacts.cs
@@ -1,0 +1,172 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using HttPlaceholder.Common;
+using HttPlaceholder.HostedServices;
+using HttPlaceholder.TestUtilities.Logging;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq.AutoMock;
+
+namespace HttPlaceholder.Tests.HostedServices;
+
+[TestClass]
+public class BackgroundServiceFacts
+{
+    private readonly AutoMocker _mocker = new();
+    private readonly MockLogger<BackgroundService> _loggerMock = new();
+
+    [TestInitialize]
+    public void Initialize() => _mocker.Use<ILogger<BackgroundService>>(_loggerMock);
+
+    [TestCleanup]
+    public void Cleanup() => _mocker.VerifyAll();
+
+    [TestMethod]
+    public async Task StartAsync_NotTimeYet_ShouldNotExecuteService()
+    {
+        // Arrange
+        var dateTimeMock = _mocker.GetMock<IDateTime>();
+        var now = new DateTime(2022, 2, 6, 4, 4, 59);
+        dateTimeMock
+            .Setup(m => m.Now)
+            .Returns(now);
+
+        var service = _mocker.CreateInstance<SucceedingBackgroundService>();
+
+        service.StoppingCts.Cancel();
+
+        // Act
+        await service.StartAsync(CancellationToken.None);
+
+        // Assert
+        Assert.IsFalse(service.ProcessCalled);
+    }
+
+    [TestMethod]
+    public async Task StartAsync_ItsTime_ShouldExecuteService()
+    {
+        // Arrange
+        var dateTimeMock = _mocker.GetMock<IDateTime>();
+        dateTimeMock
+            .Setup(m => m.Now)
+            .Returns(new DateTime(2022, 2, 6, 4, 4, 59));
+
+        var service = _mocker.CreateInstance<SucceedingBackgroundService>();
+
+        dateTimeMock
+            .Setup(m => m.Now)
+            .Returns(new DateTime(2022, 2, 6, 4, 5, 1));
+
+        service.StoppingCts.Cancel();
+
+        // Act
+        await service.StartAsync(CancellationToken.None);
+
+        // Assert
+        Assert.IsTrue(service.ProcessCalled);
+    }
+
+    [TestMethod]
+    public async Task StartAsync_ItsTime_ProcessingThrowsException_ShouldLogError()
+    {
+        // Arrange
+        var dateTimeMock = _mocker.GetMock<IDateTime>();
+        dateTimeMock
+            .Setup(m => m.Now)
+            .Returns(new DateTime(2022, 2, 6, 4, 4, 59));
+
+        var service = _mocker.CreateInstance<FailingBackgroundService>();
+
+        dateTimeMock
+            .Setup(m => m.Now)
+            .Returns(new DateTime(2022, 2, 6, 4, 5, 1));
+
+        service.StoppingCts.Cancel();
+
+        // Act
+        await service.StartAsync(CancellationToken.None);
+
+        // Assert
+        Assert.IsTrue(service.ProcessCalled);
+        var logEvent = _loggerMock.Entries.Single(e => e.LogLevel == LogLevel.Error);
+        Assert.IsTrue(logEvent.State.Contains("Unexpected exception thrown while executing service") &&
+                      logEvent.State.Contains("PROCESSING WENT WRONG!"));
+    }
+
+    [TestMethod]
+    public async Task StopAsync_StopCalledWithoutStart_ShouldDoNothing()
+    {
+        // Arrange
+        var service = _mocker.CreateInstance<SucceedingBackgroundService>();
+
+        // Act
+        await service.StopAsync(CancellationToken.None);
+
+        // Assert
+        Assert.IsFalse(service.StoppingCts.IsCancellationRequested);
+    }
+
+    [TestMethod]
+    public async Task StopAsync_ShouldCancelService()
+    {
+        // Arrange
+        var service = _mocker.CreateInstance<SucceedingBackgroundService>();
+        service.ExecutingTask = Task.CompletedTask;
+
+        // Act
+        await service.StopAsync(CancellationToken.None);
+
+        // Assert
+        Assert.IsTrue(service.StoppingCts.IsCancellationRequested);
+    }
+
+    private class SucceedingBackgroundService : BackgroundService
+    {
+        public SucceedingBackgroundService(
+            ILogger<BackgroundService> logger,
+            IDateTime dateTime,
+            IAsyncService asyncService) : base(logger, dateTime, asyncService)
+        {
+        }
+
+        public bool ProcessCalled { get; set; }
+
+        public override string Schedule => "5 4 * * *";
+
+        public override string Key => "succeeding";
+
+        public override string Description => "A succeeding background job.";
+
+        public override Task ProcessAsync()
+        {
+            ProcessCalled = true;
+            return Task.CompletedTask;
+        }
+    }
+
+    private class FailingBackgroundService : BackgroundService
+    {
+        public FailingBackgroundService(
+            ILogger<BackgroundService> logger,
+            IDateTime dateTime,
+            IAsyncService asyncService) : base(logger, dateTime, asyncService)
+        {
+        }
+
+        public bool ProcessCalled { get; set; }
+
+        public override string Schedule => "5 4 * * *";
+
+        public override string Key => "failing";
+
+        public override string Description => "A failing background job.";
+
+        public override Task ProcessAsync()
+        {
+            ProcessCalled = true;
+            throw new InvalidOperationException("PROCESSING WENT WRONG!");
+        }
+    }
+}

--- a/src/HttPlaceholder.Tests/HostedServices/CleanOldRequestsJobFacts.cs
+++ b/src/HttPlaceholder.Tests/HostedServices/CleanOldRequestsJobFacts.cs
@@ -1,0 +1,30 @@
+﻿using System.Threading.Tasks;
+using HttPlaceholder.Application.StubExecution;
+using HttPlaceholder.HostedServices;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq.AutoMock;
+
+namespace HttPlaceholder.Tests.HostedServices;
+
+[TestClass]
+public class CleanOldRequestsJobFacts
+{
+    private readonly AutoMocker _mocker = new();
+
+    [TestCleanup]
+    public void Cleanup() => _mocker.VerifyAll();
+
+    [TestMethod]
+    public async Task ProcessAsync_HappyFlow()
+    {
+        // Arrange
+        var stubContextMock = _mocker.GetMock<IStubContext>();
+        var job = _mocker.CreateInstance<CleanOldRequestsJob>();
+
+        // Act
+        await job.ProcessAsync();
+
+        // Assert
+        stubContextMock.Verify(m => m.CleanOldRequestResultsAsync());
+    }
+}

--- a/src/HttPlaceholder.Tests/HostedServices/HostedServiceModuleFacts.cs
+++ b/src/HttPlaceholder.Tests/HostedServices/HostedServiceModuleFacts.cs
@@ -35,8 +35,8 @@ public class HostedServiceModuleFacts
         services.AddHostedServices(BuildConfiguration(args));
 
         // Assert
-        Assert.AreEqual(1, services.Count);
-        Assert.IsTrue(services.Any(s => s.ImplementationType == typeof(CleanOldRequestsJob)));
+        Assert.AreEqual(2, services.Count);
+        Assert.IsTrue(services.All(s => s.ImplementationType == typeof(CleanOldRequestsJob)));
     }
 
     private static IConfiguration BuildConfiguration(IDictionary<string, string> dict) =>

--- a/src/HttPlaceholder.Tests/HostedServices/HostedServiceModuleFacts.cs
+++ b/src/HttPlaceholder.Tests/HostedServices/HostedServiceModuleFacts.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using HttPlaceholder.HostedServices;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HttPlaceholder.Tests.HostedServices;
+
+[TestClass]
+public class HostedServiceModuleFacts
+{
+    [TestMethod]
+    public void AddHostedServices_CleanOldRequestsInBackgroundJobIsFalse_ShouldNotRegisterCleanOldRequestsJob()
+    {
+        // Arrange
+        var args = new Dictionary<string, string> {{"Storage:CleanOldRequestsInBackgroundJob", "false"}};
+        var services = new ServiceCollection();
+
+        // Act
+        services.AddHostedServices(BuildConfiguration(args));
+
+        // Assert
+        Assert.AreEqual(0, services.Count);
+    }
+
+    [TestMethod]
+    public void AddHostedServices_CleanOldRequestsInBackgroundJobIsTrue_ShouldRegisterCleanOldRequestsJob()
+    {
+        // Arrange
+        var args = new Dictionary<string, string> {{"Storage:CleanOldRequestsInBackgroundJob", "true"}};
+        var services = new ServiceCollection();
+
+        // Act
+        services.AddHostedServices(BuildConfiguration(args));
+
+        // Assert
+        Assert.AreEqual(1, services.Count);
+        Assert.IsTrue(services.Any(s => s.ImplementationType == typeof(CleanOldRequestsJob)));
+    }
+
+    private static IConfiguration BuildConfiguration(IDictionary<string, string> dict) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(dict)
+            .Build();
+}

--- a/src/HttPlaceholder.Tests/Integration/IntegrationTestBase.cs
+++ b/src/HttPlaceholder.Tests/Integration/IntegrationTestBase.cs
@@ -32,7 +32,8 @@ public abstract class IntegrationTestBase
         var config = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string>
             {
-                { "Storage:InputFile", @"C:\tmp" }
+                { "Storage:InputFile", @"C:\tmp" },
+                { "Storage:CleanOldRequestsInBackgroundJob", "true" },
             })
             .Build();
         var startup = new Startup(config);

--- a/src/HttPlaceholder.Tests/Integration/RestApi/RestApiCleanOldRequestsTests.cs
+++ b/src/HttPlaceholder.Tests/Integration/RestApi/RestApiCleanOldRequestsTests.cs
@@ -1,0 +1,51 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+using HttPlaceholder.Dto.v1.Requests;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+
+namespace HttPlaceholder.Tests.Integration.RestApi;
+
+[TestClass]
+public class RestApiCleanOldRequestsTests : RestApiIntegrationTestBase
+{
+    [TestInitialize]
+    public void Initialize()
+    {
+        Options.Value.Storage.CleanOldRequestsInBackgroundJob = true;
+        InitializeRestApiIntegrationTest();
+    }
+
+    [TestCleanup]
+    public void Cleanup() => CleanupRestApiIntegrationTest();
+
+    [TestMethod]
+    public async Task RestApiIntegration_CleanOldRequests_HappyFlow()
+    {
+        // Perform a lot of requests.
+        for (var i = 0; i < 45; i++)
+        {
+            await Client.GetAsync($"{BaseAddress}some-request");
+        }
+
+        // Verify the number of performed requests.
+        var requests = await GetRequestOverviewAsync();
+        Assert.AreEqual(45, requests.Length);
+
+        // Run the cleaning job.
+        using var scheduledJobResponse = await Client.PostAsync($"{BaseAddress}ph-api/scheduledJob/CleanOldRequestsJob", new StringContent(string.Empty));
+        scheduledJobResponse.EnsureSuccessStatusCode();
+
+        // Verify the number of performed requests.
+        requests = await GetRequestOverviewAsync();
+        Assert.AreEqual(40, requests.Length);
+    }
+
+    private async Task<RequestOverviewDto[]> GetRequestOverviewAsync()
+    {
+        using var response = await Client.GetAsync($"{BaseAddress}ph-api/requests/overview");
+        response.EnsureSuccessStatusCode();
+        var content = await response.Content.ReadAsStringAsync();
+        return JsonConvert.DeserializeObject<RequestOverviewDto[]>(content);
+    }
+}

--- a/src/HttPlaceholder.Tests/Integration/RestApi/RestApiScheduledJobTests.cs
+++ b/src/HttPlaceholder.Tests/Integration/RestApi/RestApiScheduledJobTests.cs
@@ -1,0 +1,24 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HttPlaceholder.Tests.Integration.RestApi;
+
+[TestClass]
+public class RestApiScheduledJobTests : RestApiIntegrationTestBase
+{
+    [TestInitialize]
+    public void Initialize() => InitializeRestApiIntegrationTest();
+
+    [TestCleanup]
+    public void Cleanup() => CleanupRestApiIntegrationTest();
+
+    [TestMethod]
+    public async Task RestApiIntegration_ScheduledJobs_ScheduledJobNotFound_ShouldReturn404()
+    {
+        // Run a non-existent job.
+        using var scheduledJobResponse = await Client.PostAsync($"{BaseAddress}ph-api/scheduledJob/NotExists", new StringContent(string.Empty));
+        Assert.AreEqual(HttpStatusCode.NotFound, scheduledJobResponse.StatusCode);
+    }
+}

--- a/src/HttPlaceholder.Tests/Integration/Stubs/StubGeneralIntegrationTests.cs
+++ b/src/HttPlaceholder.Tests/Integration/Stubs/StubGeneralIntegrationTests.cs
@@ -9,7 +9,11 @@ namespace HttPlaceholder.Tests.Integration.Stubs;
 public class StubGeneralIntegrationTests : StubIntegrationTestBase
 {
     [TestInitialize]
-    public void Initialize() => InitializeStubIntegrationTest("Resources/integration.yml");
+    public void Initialize()
+    {
+        Settings.Gui.EnableUserInterface = true;
+        InitializeStubIntegrationTest("Resources/integration.yml");
+    }
 
     [TestCleanup]
     public void Cleanup() => CleanupIntegrationTest();

--- a/src/HttPlaceholder/Controllers/v1/ScheduledJobController.cs
+++ b/src/HttPlaceholder/Controllers/v1/ScheduledJobController.cs
@@ -59,7 +59,7 @@ public class ScheduledJobController : BaseApiController
             statusCode = HttpStatusCode.InternalServerError;
         }
 
-        return StatusCode((int)statusCode, new JobExecutionResultModel(message));
+        return StatusCode((int)statusCode, new JobExecutionResultDto(message));
     }
 
     /// <summary>

--- a/src/HttPlaceholder/Controllers/v1/ScheduledJobController.cs
+++ b/src/HttPlaceholder/Controllers/v1/ScheduledJobController.cs
@@ -61,4 +61,12 @@ public class ScheduledJobController : BaseApiController
 
         return StatusCode((int)statusCode, new JobExecutionResultModel(message));
     }
+
+    /// <summary>
+    /// An endpoint for retrieving all the scheduled job names that can can be executed.
+    /// </summary>
+    /// <returns>A list of scheduled job names.</returns>
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public ActionResult<IEnumerable<string>> GetScheduledJobNames() => Ok(_hostedServices.Select(s => s.Key));
 }

--- a/src/HttPlaceholder/Controllers/v1/ScheduledJobController.cs
+++ b/src/HttPlaceholder/Controllers/v1/ScheduledJobController.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using HttPlaceholder.Application.Exceptions;
+using HttPlaceholder.Authorization;
+using HttPlaceholder.Dto.v1.ScheduledJobs;
+using HttPlaceholder.HostedServices;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace HttPlaceholder.Controllers.v1;
+
+/// <summary>
+/// A controller that is used for manually calling a scheduled job.
+/// </summary>
+[Route("ph-api/scheduledJob")]
+[ApiAuthorization]
+public class ScheduledJobController : BaseApiController
+{
+    private readonly IEnumerable<ICustomHostedService> _hostedServices;
+
+    /// <summary>
+    /// Constructs a <see cref="ScheduledJobController"/> instance.
+    /// </summary>
+    public ScheduledJobController(IEnumerable<ICustomHostedService> hostedServices)
+    {
+        _hostedServices = hostedServices;
+    }
+
+    /// <summary>
+    /// Runs a specified scheduled job.
+    /// </summary>
+    /// <param name="jobName">The name of the scheduled job to run.</param>
+    /// <returns>OK.</returns>
+    [HttpPost("{jobName}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult> RunScheduledJob([FromRoute] string jobName)
+    {
+        var message = "OK";
+        var job = _hostedServices.FirstOrDefault(s =>
+            string.Equals(jobName, s.Key, StringComparison.OrdinalIgnoreCase));
+        if (job == null)
+        {
+            throw new NotFoundException($"Hosted service with key '{jobName}'.");
+        }
+
+        var statusCode = HttpStatusCode.OK;
+        try
+        {
+            await job.ProcessAsync();
+        }
+        catch (Exception ex)
+        {
+            message = ex.ToString();
+            statusCode = HttpStatusCode.InternalServerError;
+        }
+
+        return StatusCode((int)statusCode, new JobExecutionResultModel(message));
+    }
+}

--- a/src/HttPlaceholder/Controllers/v1/StubController.cs
+++ b/src/HttPlaceholder/Controllers/v1/StubController.cs
@@ -54,7 +54,7 @@ public class StubController : BaseApiController
     /// </summary>
     /// <param name="stub">The posted stub.</param>
     /// <param name="stubId">The stub ID.</param>
-    /// <returns>OK, but no content returned</returns>
+    /// <returns>OK, but no content returned.</returns>
     [HttpPut("{stubId}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]

--- a/src/HttPlaceholder/Dto/v1/ScheduledJobs/JobExecutionResultDto.cs
+++ b/src/HttPlaceholder/Dto/v1/ScheduledJobs/JobExecutionResultDto.cs
@@ -3,12 +3,12 @@
 /// <summary>
 /// A model that is returned when a scheduled job has executed through the API.
 /// </summary>
-public class JobExecutionResultModel
+public class JobExecutionResultDto
 {
     /// <summary>
-    /// Constructs a <see cref="JobExecutionResultModel"/> instance.
+    /// Constructs a <see cref="JobExecutionResultDto"/> instance.
     /// </summary>
-    public JobExecutionResultModel(string message)
+    public JobExecutionResultDto(string message)
     {
         Message = message;
     }

--- a/src/HttPlaceholder/Dto/v1/ScheduledJobs/JobExecutionResultModel.cs
+++ b/src/HttPlaceholder/Dto/v1/ScheduledJobs/JobExecutionResultModel.cs
@@ -1,0 +1,20 @@
+﻿namespace HttPlaceholder.Dto.v1.ScheduledJobs;
+
+/// <summary>
+/// A model that is returned when a scheduled job has executed through the API.
+/// </summary>
+public class JobExecutionResultModel
+{
+    /// <summary>
+    /// Constructs a <see cref="JobExecutionResultModel"/> instance.
+    /// </summary>
+    public JobExecutionResultModel(string message)
+    {
+        Message = message;
+    }
+
+    /// <summary>
+    /// Gets or sets message.
+    /// </summary>
+    public string Message { get; }
+}

--- a/src/HttPlaceholder/HostedServices/BackgroundService.cs
+++ b/src/HttPlaceholder/HostedServices/BackgroundService.cs
@@ -13,8 +13,8 @@ namespace HttPlaceholder.HostedServices;
 /// </summary>
 public abstract class BackgroundService : ICustomHostedService
 {
-    private Task _executingTask;
-    private readonly CancellationTokenSource _stoppingCts = new();
+    internal readonly CancellationTokenSource StoppingCts = new();
+    internal Task ExecutingTask;
     private readonly CrontabSchedule _schedule;
 
     /// <summary>
@@ -23,17 +23,20 @@ public abstract class BackgroundService : ICustomHostedService
     protected readonly ILogger<BackgroundService> Logger;
 
     private readonly IDateTime _dateTime;
+    private readonly IAsyncService _asyncService;
 
     /// <summary>
     /// Constructs a <see cref="BackgroundService"/> instance.
     /// </summary>
     protected BackgroundService(
         ILogger<BackgroundService> logger,
-        IDateTime dateTime)
+        IDateTime dateTime,
+        IAsyncService asyncService)
     {
         _schedule = CrontabSchedule.Parse(Schedule);
         Logger = logger;
         _dateTime = dateTime;
+        _asyncService = asyncService;
         NextRunDateTime = _schedule.GetNextOccurrence(_dateTime.Now);
         Logger.LogInformation(
             $"New hosted service with name '{GetType().Name}' and schedule '{Schedule}' and the next occurrence will be on '{NextRunDateTime}'");
@@ -55,17 +58,17 @@ public abstract class BackgroundService : ICustomHostedService
     public virtual Task StartAsync(CancellationToken cancellationToken)
     {
         // Store the task we're executing.
-        _executingTask = ExecuteAsync(_stoppingCts.Token);
+        ExecutingTask = ExecuteAsync(StoppingCts.Token);
 
         // If the task is completed then return it, this will bubble cancellation and failure to the caller.
-        return _executingTask.IsCompleted ? _executingTask : Task.CompletedTask;
+        return ExecutingTask.IsCompleted ? ExecutingTask : Task.CompletedTask;
     }
 
     /// <inheritdoc />
     public virtual async Task StopAsync(CancellationToken cancellationToken)
     {
-        // Stop called without start
-        if (_executingTask == null)
+        // Stop called without start.
+        if (ExecutingTask == null)
         {
             return;
         }
@@ -73,12 +76,12 @@ public abstract class BackgroundService : ICustomHostedService
         try
         {
             // Signal cancellation to the executing method.
-            _stoppingCts.Cancel();
+            StoppingCts.Cancel();
         }
         finally
         {
             // Wait until the task completes or the stop token triggers.
-            await Task.WhenAny(_executingTask, Task.Delay(Timeout.Infinite,
+            await Task.WhenAny(ExecutingTask, Task.Delay(Timeout.Infinite,
                 cancellationToken));
         }
     }
@@ -104,7 +107,7 @@ public abstract class BackgroundService : ICustomHostedService
                 Logger.LogDebug($"Next run time of hosted service '{GetType().Name}': {NextRunDateTime}");
             }
 
-            await Task.Delay(5000, stoppingToken);
+            await _asyncService.DelayAsync(5000, stoppingToken);
         } while (!stoppingToken.IsCancellationRequested);
     }
 

--- a/src/HttPlaceholder/HostedServices/BackgroundService.cs
+++ b/src/HttPlaceholder/HostedServices/BackgroundService.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using HttPlaceholder.Common;
+using Microsoft.Extensions.Logging;
+using NCrontab;
+
+namespace HttPlaceholder.HostedServices;
+
+/// <summary>
+/// An abstract class that needs to be implemented by any hosted service.
+/// Source: https://github.com/pgroene/ASPNETCoreScheduler/blob/master/ASPNETCoreScheduler/BackgroundService/BackgroundService.cs
+/// </summary>
+public abstract class BackgroundService : ICustomHostedService
+{
+    private Task _executingTask;
+    private readonly CancellationTokenSource _stoppingCts = new();
+    private readonly CrontabSchedule _schedule;
+
+    /// <summary>
+    /// The logger.
+    /// </summary>
+    protected readonly ILogger<BackgroundService> Logger;
+
+    private readonly IDateTime _dateTime;
+
+    /// <summary>
+    /// Constructs a <see cref="BackgroundService"/> instance.
+    /// </summary>
+    protected BackgroundService(
+        ILogger<BackgroundService> logger,
+        IDateTime dateTime)
+    {
+        _schedule = CrontabSchedule.Parse(Schedule);
+        Logger = logger;
+        _dateTime = dateTime;
+        NextRunDateTime = _schedule.GetNextOccurrence(_dateTime.Now);
+        Logger.LogInformation(
+            $"New hosted service with name '{GetType().Name}' and schedule '{Schedule}' and the next occurrence will be on '{NextRunDateTime}'");
+    }
+
+    /// <inheritdoc />
+    public abstract string Schedule { get; }
+
+    /// <inheritdoc />
+    public abstract string Key { get; }
+
+    /// <inheritdoc />
+    public abstract string Description { get; }
+
+    /// <inheritdoc />
+    public DateTime NextRunDateTime { get; private set; }
+
+    /// <inheritdoc />
+    public virtual Task StartAsync(CancellationToken cancellationToken)
+    {
+        // Store the task we're executing.
+        _executingTask = ExecuteAsync(_stoppingCts.Token);
+
+        // If the task is completed then return it, this will bubble cancellation and failure to the caller.
+        return _executingTask.IsCompleted ? _executingTask : Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public virtual async Task StopAsync(CancellationToken cancellationToken)
+    {
+        // Stop called without start
+        if (_executingTask == null)
+        {
+            return;
+        }
+
+        try
+        {
+            // Signal cancellation to the executing method.
+            _stoppingCts.Cancel();
+        }
+        finally
+        {
+            // Wait until the task completes or the stop token triggers.
+            await Task.WhenAny(_executingTask, Task.Delay(Timeout.Infinite,
+                cancellationToken));
+        }
+    }
+
+    private async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        do
+        {
+            if (_dateTime.Now > NextRunDateTime)
+            {
+                Logger.LogInformation(
+                    $"Executing hosted service with name '{GetType().Name}' and schedule '{Schedule}'");
+                try
+                {
+                    await ProcessAsync();
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError($"Unexpected exception thrown while executing service '{GetType().Name}': {ex}");
+                }
+
+                NextRunDateTime = _schedule.GetNextOccurrence(_dateTime.Now);
+                Logger.LogDebug($"Next run time of hosted service '{GetType().Name}': {NextRunDateTime}");
+            }
+
+            await Task.Delay(5000, stoppingToken);
+        } while (!stoppingToken.IsCancellationRequested);
+    }
+
+    /// <inheritdoc />
+    public abstract Task ProcessAsync();
+}

--- a/src/HttPlaceholder/HostedServices/CleanOldRequestsJob.cs
+++ b/src/HttPlaceholder/HostedServices/CleanOldRequestsJob.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using HttPlaceholder.Application.StubExecution;
 using HttPlaceholder.Common;
 using Microsoft.Extensions.Logging;
 
@@ -9,12 +10,16 @@ namespace HttPlaceholder.HostedServices;
 /// </summary>
 public class CleanOldRequestsJob : BackgroundService
 {
+    private readonly IStubContext _stubContext;
+
     /// <summary>
     /// Constructs a <see cref="CleanOldRequestsJob"/> instance.
     /// </summary>
-    public CleanOldRequestsJob(ILogger<BackgroundService> logger, IDateTime dateTime, IAsyncService asyncService) :
+    public CleanOldRequestsJob(ILogger<BackgroundService> logger, IDateTime dateTime, IAsyncService asyncService,
+        IStubContext stubContext) :
         base(logger, dateTime, asyncService)
     {
+        _stubContext = stubContext;
     }
 
     /// <inheritdoc />
@@ -27,5 +32,9 @@ public class CleanOldRequestsJob : BackgroundService
     public override string Description => "A job for cleaning old requests.";
 
     /// <inheritdoc />
-    public override Task ProcessAsync() => throw new System.NotImplementedException();
+    public override async Task ProcessAsync()
+    {
+        Logger.LogDebug("Cleaning old requests.");
+        await _stubContext.CleanOldRequestResultsAsync();
+    }
 }

--- a/src/HttPlaceholder/HostedServices/CleanOldRequestsJob.cs
+++ b/src/HttPlaceholder/HostedServices/CleanOldRequestsJob.cs
@@ -1,0 +1,31 @@
+﻿using System.Threading.Tasks;
+using HttPlaceholder.Common;
+using Microsoft.Extensions.Logging;
+
+namespace HttPlaceholder.HostedServices;
+
+/// <summary>
+/// A background that is used to clean old requests
+/// </summary>
+public class CleanOldRequestsJob : BackgroundService
+{
+    /// <summary>
+    /// Constructs a <see cref="CleanOldRequestsJob"/> instance.
+    /// </summary>
+    public CleanOldRequestsJob(ILogger<BackgroundService> logger, IDateTime dateTime, IAsyncService asyncService) :
+        base(logger, dateTime, asyncService)
+    {
+    }
+
+    /// <inheritdoc />
+    public override string Schedule => "*/5 * * * *";
+
+    /// <inheritdoc />
+    public override string Key => "CleanOldRequestsJob";
+
+    /// <inheritdoc />
+    public override string Description => "A job for cleaning old requests.";
+
+    /// <inheritdoc />
+    public override Task ProcessAsync() => throw new System.NotImplementedException();
+}

--- a/src/HttPlaceholder/HostedServices/HostedServiceModule.cs
+++ b/src/HttPlaceholder/HostedServices/HostedServiceModule.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using HttPlaceholder.Application.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
+using IConfiguration = Microsoft.Extensions.Configuration.IConfiguration;
 
 namespace HttPlaceholder.HostedServices;
 
@@ -11,5 +14,17 @@ public static class HostedServiceModule
     /// A method for registering all hosted services.
     /// </summary>
     /// <param name="services">The service collection.</param>
-    public static IServiceCollection AddHostedServices(this IServiceCollection services) => services;
+    /// <param name="configuration">The configuration.</param>
+    public static IServiceCollection AddHostedServices(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        var settings = configuration.Get<SettingsModel>();
+        if (settings.Storage?.CleanOldRequestsInBackgroundJob == true)
+        {
+            services.AddHostedService<CleanOldRequestsJob>();
+        }
+
+        return services;
+    }
 }

--- a/src/HttPlaceholder/HostedServices/HostedServiceModule.cs
+++ b/src/HttPlaceholder/HostedServices/HostedServiceModule.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace HttPlaceholder.HostedServices;
+
+/// <summary>
+/// A class for registering all hosted services.
+/// </summary>
+public static class HostedServiceModule
+{
+    /// <summary>
+    /// A method for registering all hosted services.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    public static IServiceCollection AddHostedServices(this IServiceCollection services) => services;
+}

--- a/src/HttPlaceholder/HostedServices/HostedServiceModule.cs
+++ b/src/HttPlaceholder/HostedServices/HostedServiceModule.cs
@@ -20,7 +20,7 @@ public static class HostedServiceModule
         IConfiguration configuration)
     {
         var settings = configuration.Get<SettingsModel>();
-        if (settings.Storage?.CleanOldRequestsInBackgroundJob == true)
+        if (settings?.Storage?.CleanOldRequestsInBackgroundJob == true)
         {
             services.AddHostedService<CleanOldRequestsJob>();
         }

--- a/src/HttPlaceholder/HostedServices/HostedServiceModule.cs
+++ b/src/HttPlaceholder/HostedServices/HostedServiceModule.cs
@@ -22,7 +22,7 @@ public static class HostedServiceModule
         var settings = configuration.Get<SettingsModel>();
         if (settings?.Storage?.CleanOldRequestsInBackgroundJob == true)
         {
-            services.AddHostedService<CleanOldRequestsJob>();
+            services.RegisterCustomHostedService<CleanOldRequestsJob>();
         }
 
         return services;

--- a/src/HttPlaceholder/HostedServices/HostedServiceUtilities.cs
+++ b/src/HttPlaceholder/HostedServices/HostedServiceUtilities.cs
@@ -1,0 +1,22 @@
+﻿using HttPlaceholder.Controllers.v1;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace HttPlaceholder.HostedServices;
+
+/// <summary>
+/// A utility class that is used for working with hosted services.
+/// </summary>
+public static class HostedServiceUtilities
+{
+    /// <summary>
+    /// A method for registering a hosted service.
+    /// It also registers an additional "transient" dependency on the service container so they can be used in the <see cref="ScheduledJobController"/>.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <typeparam name="THostedService">The type of the hosted service.</typeparam>
+    public static IServiceCollection RegisterCustomHostedService<THostedService>(this IServiceCollection services)
+        where THostedService : class, ICustomHostedService =>
+        services
+            .AddHostedService<THostedService>()
+            .AddTransient<ICustomHostedService, THostedService>();
+}

--- a/src/HttPlaceholder/HostedServices/ICustomHostedService.cs
+++ b/src/HttPlaceholder/HostedServices/ICustomHostedService.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+
+namespace HttPlaceholder.HostedServices;
+
+/// <summary>
+/// Describes a class that implements a hosted service.
+/// </summary>
+public interface ICustomHostedService : IHostedService
+{
+    /// <summary>
+    /// Gets the job schedule as cron.
+    /// </summary>
+    string Schedule { get; }
+
+    /// <summary>
+    /// Gets the hosted service key.
+    /// </summary>
+    string Key { get; }
+
+    /// <summary>
+    /// Gets the hosted service description.
+    /// </summary>
+    string Description { get; }
+
+    /// <summary>
+    /// Gets the next run date/time of the hosted service.
+    /// </summary>
+    DateTime NextRunDateTime { get; }
+
+    /// <summary>
+    /// Executed the hosted service.
+    /// </summary>
+    Task ProcessAsync();
+}

--- a/src/HttPlaceholder/HttPlaceholder.csproj
+++ b/src/HttPlaceholder/HttPlaceholder.csproj
@@ -31,6 +31,7 @@
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
+        <PackageReference Include="ncrontab" Version="3.3.1" />
         <PackageReference Include="NSwag.AspNetCore" Version="13.15.3" />
         <PackageReference Include="Serilog" Version="2.10.0" />
         <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />

--- a/src/HttPlaceholder/HttPlaceholder.csproj
+++ b/src/HttPlaceholder/HttPlaceholder.csproj
@@ -25,7 +25,7 @@
         <PackageIcon>logo.png</PackageIcon>
     </PropertyGroup>
     <ItemGroup>
-        <None Include="../media/logo.png" Pack="true" Visible="false" PackagePath=""/>
+        <None Include="../media/logo.png" Pack="true" Visible="false" PackagePath="" />
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.0" />

--- a/src/HttPlaceholder/HttPlaceholder.csproj
+++ b/src/HttPlaceholder/HttPlaceholder.csproj
@@ -30,6 +30,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
         <PackageReference Include="ncrontab" Version="3.3.1" />
         <PackageReference Include="NSwag.AspNetCore" Version="13.15.3" />

--- a/src/HttPlaceholder/Middleware/StubHandlingMiddleware.cs
+++ b/src/HttPlaceholder/Middleware/StubHandlingMiddleware.cs
@@ -117,10 +117,14 @@ public class StubHandlingMiddleware
         {
             _httpContextService.SetStatusCode(HttpStatusCode.NotImplemented);
             _httpContextService.TryAddHeader(correlationHeaderKey, correlation);
-            var pageContents =
-                StaticResources.stub_not_configured_html_page.Replace("[ROOT_URL]", _httpContextService.RootUrl);
-            _httpContextService.AddHeader("Content-Type", Constants.HtmlMime);
-            await _httpContextService.WriteAsync(pageContents);
+            if (_settings?.Gui?.EnableUserInterface == true)
+            {
+                var pageContents =
+                    StaticResources.stub_not_configured_html_page.Replace("[ROOT_URL]", _httpContextService.RootUrl);
+                _httpContextService.AddHeader("Content-Type", Constants.HtmlMime);
+                await _httpContextService.WriteAsync(pageContents);
+            }
+
             _logger.LogInformation($"Request validation exception thrown: {e.Message}");
         }
         catch (Exception e)

--- a/src/HttPlaceholder/Utilities/StartupUtilities.cs
+++ b/src/HttPlaceholder/Utilities/StartupUtilities.cs
@@ -5,6 +5,7 @@ using HttPlaceholder.Application.Interfaces.Http;
 using HttPlaceholder.Application.StubExecution;
 using HttPlaceholder.Authorization;
 using HttPlaceholder.Common.Utilities;
+using HttPlaceholder.HostedServices;
 using HttPlaceholder.Hubs;
 using HttPlaceholder.Infrastructure;
 using HttPlaceholder.Infrastructure.Web;
@@ -38,6 +39,7 @@ public static class StartupUtilities
             .AddPersistenceModule(configuration)
             .AddAuthorizationModule()
             .AddSignalRHubs()
+            .AddHostedServices()
             .AddWebInfrastructure()
             .AddAutoMapper(
                 config => config.AllowNullCollections = true,

--- a/src/HttPlaceholder/Utilities/StartupUtilities.cs
+++ b/src/HttPlaceholder/Utilities/StartupUtilities.cs
@@ -39,7 +39,7 @@ public static class StartupUtilities
             .AddPersistenceModule(configuration)
             .AddAuthorizationModule()
             .AddSignalRHubs()
-            .AddHostedServices()
+            .AddHostedServices(configuration)
             .AddWebInfrastructure()
             .AddAutoMapper(
                 config => config.AllowNullCollections = true,

--- a/test/HttPlaceholderIntegration.postman_collection.json
+++ b/test/HttPlaceholderIntegration.postman_collection.json
@@ -7639,6 +7639,57 @@
 									"response": []
 								}
 							]
+						},
+						{
+							"name": "9. Scheduled jobs",
+							"item": [
+								{
+									"name": "Run \"clean old requests\" job",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"const jsonData = pm.response.json();",
+													"",
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Everything went OK\", function() {",
+													"    pm.expect(jsonData.message).to.eql(\"OK\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "openapi: \"3.0.0\"\ninfo:\n  version: 1.0.0\n  title: Swagger Petstore\n  license:\n    name: MIT\nservers:\n  - url: http://petstore.swagger.io/v1\npaths:\n  /pets:\n    get:\n      summary: List all pets\n      operationId: listPets\n      tags:\n        - pets\n      parameters:\n        - name: limit\n          in: query\n          description: How many items to return at one time (max 100)\n          required: false\n          schema:\n            type: integer\n            format: int32\n        - name: X-Api-Key\n          in: header\n          description: API key.\n          schema:\n            type: string\n      responses:\n        '200':\n          description: A paged array of pets\n          headers:\n            x-next:\n              description: A link to the next page of responses\n              schema:\n                type: string\n          content:\n            application/json:\n              schema:\n                $ref: \"#/components/schemas/Pets\"\n              example:\n                - id: 1\n                  name: Cat\n                - id: 2\n                  name: Dog\n        default:\n          description: unexpected error\n          content:\n            application/json:\n              schema:\n                $ref: \"#/components/schemas/Error\"\n    post:\n      summary: Create a pet\n      operationId: createPets\n      tags:\n        - pets\n      responses:\n        '201':\n          description: Null response\n        default:\n          description: unexpected error\n          content:\n            application/json:\n              schema:\n                $ref: \"#/components/schemas/Error\"\n  /pets/{petId}:\n    get:\n      summary: Info for a specific pet\n      operationId: showPetById\n      tags:\n        - pets\n      parameters:\n        - name: petId\n          in: path\n          required: true\n          description: The id of the pet to retrieve\n          schema:\n            type: string\n      responses:\n        '200':\n          description: Expected response to a valid request\n          content:\n            application/json:\n              schema:\n                $ref: \"#/components/schemas/Pet\"\n        default:\n          description: unexpected error\n          content:\n            application/json:\n              schema:\n                $ref: \"#/components/schemas/Error\"\ncomponents:\n  schemas:\n    Pet:\n      type: object\n      required:\n        - id\n        - name\n      properties:\n        id:\n          type: integer\n          format: int64\n        name:\n          type: string\n        tag:\n          type: string\n        petType:\n          type: string\n          enum: [cat, dog, rabbit]\n    Pets:\n      type: array\n      items:\n        $ref: \"#/components/schemas/Pet\"\n    Error:\n      type: object\n      required:\n        - code\n        - message\n      properties:\n        code:\n          type: integer\n          format: int32\n        message:\n          type: string\n",
+											"options": {
+												"raw": {
+													"language": "text"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{rootUrl}}ph-api/scheduledJob/CleanOldRequestsJob",
+											"host": [
+												"{{rootUrl}}ph-api"
+											],
+											"path": [
+												"scheduledJob",
+												"CleanOldRequestsJob"
+											]
+										}
+									},
+									"response": []
+								}
+							]
 						}
 					]
 				},

--- a/test/HttPlaceholderIntegration.postman_collection.json
+++ b/test/HttPlaceholderIntegration.postman_collection.json
@@ -7688,6 +7688,55 @@
 										}
 									},
 									"response": []
+								},
+								{
+									"name": "Get scheduled job names",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"const jsonData = pm.response.json();",
+													"",
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Correct jobs returned\", function() {",
+													"    pm.expect(jsonData.length).to.eql(1);",
+													"    pm.expect(jsonData[0]).to.eql(\"CleanOldRequestsJob\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "GET",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "openapi: \"3.0.0\"\ninfo:\n  version: 1.0.0\n  title: Swagger Petstore\n  license:\n    name: MIT\nservers:\n  - url: http://petstore.swagger.io/v1\npaths:\n  /pets:\n    get:\n      summary: List all pets\n      operationId: listPets\n      tags:\n        - pets\n      parameters:\n        - name: limit\n          in: query\n          description: How many items to return at one time (max 100)\n          required: false\n          schema:\n            type: integer\n            format: int32\n        - name: X-Api-Key\n          in: header\n          description: API key.\n          schema:\n            type: string\n      responses:\n        '200':\n          description: A paged array of pets\n          headers:\n            x-next:\n              description: A link to the next page of responses\n              schema:\n                type: string\n          content:\n            application/json:\n              schema:\n                $ref: \"#/components/schemas/Pets\"\n              example:\n                - id: 1\n                  name: Cat\n                - id: 2\n                  name: Dog\n        default:\n          description: unexpected error\n          content:\n            application/json:\n              schema:\n                $ref: \"#/components/schemas/Error\"\n    post:\n      summary: Create a pet\n      operationId: createPets\n      tags:\n        - pets\n      responses:\n        '201':\n          description: Null response\n        default:\n          description: unexpected error\n          content:\n            application/json:\n              schema:\n                $ref: \"#/components/schemas/Error\"\n  /pets/{petId}:\n    get:\n      summary: Info for a specific pet\n      operationId: showPetById\n      tags:\n        - pets\n      parameters:\n        - name: petId\n          in: path\n          required: true\n          description: The id of the pet to retrieve\n          schema:\n            type: string\n      responses:\n        '200':\n          description: Expected response to a valid request\n          content:\n            application/json:\n              schema:\n                $ref: \"#/components/schemas/Pet\"\n        default:\n          description: unexpected error\n          content:\n            application/json:\n              schema:\n                $ref: \"#/components/schemas/Error\"\ncomponents:\n  schemas:\n    Pet:\n      type: object\n      required:\n        - id\n        - name\n      properties:\n        id:\n          type: integer\n          format: int64\n        name:\n          type: string\n        tag:\n          type: string\n        petType:\n          type: string\n          enum: [cat, dog, rabbit]\n    Pets:\n      type: array\n      items:\n        $ref: \"#/components/schemas/Pet\"\n    Error:\n      type: object\n      required:\n        - code\n        - message\n      properties:\n        code:\n          type: integer\n          format: int32\n        message:\n          type: string\n",
+											"options": {
+												"raw": {
+													"language": "text"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{rootUrl}}ph-api/scheduledJob",
+											"host": [
+												"{{rootUrl}}ph-api"
+											],
+											"path": [
+												"scheduledJob"
+											]
+										}
+									},
+									"response": []
 								}
 							]
 						}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #216 

## What is the new behavior?

See #216 

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

The "clean old requests" job is now enabled by default. If you want HttPlaceholder to continue cleaning requests in the old way, set `cleanOldRequestsInBackgroundJob` to `false` to not get a bigger bill on your serverless database than needed.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
