### PR TITLE
Feature/response body validation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,9 +13,11 @@
 - Replaced Vuex with Pinia for state storage in the frontend application (https://github.com/dukeofharen/httplaceholder/pull/218).
 - Use Vite as build system and migrated all JavaScript to TypeScript (https://github.com/dukeofharen/httplaceholder/pull/219).
 - Added badges that show the currently active filters and added a simple way to clear the filters (https://github.com/dukeofharen/httplaceholder/pull/220).
+- Added stub validator to check that only 1 response writer is active in the stub (https://github.com/dukeofharen/httplaceholder/pull/221).
 
 # BREAKING CHANGES
 - As mentioned before, the "clean old requests" job is now enabled by default. If you want HttPlaceholder to continue cleaning requests in the old way, set `cleanOldRequestsInBackgroundJob` to `false` to not get a bigger bill on your serverless database than needed.
+- Like described above, it is now not possible anymore to define more than 1 response writer. Before this, it would be useless to do this anyway because only 1 response body writer can be used, but it is now not possible anymore.
 
 [1.4.0]
 - Use Roboto Mono as font for user interface.

--- a/src/HttPlaceholder.Application/StubExecution/Implementations/StubModelValidator.cs
+++ b/src/HttPlaceholder.Application/StubExecution/Implementations/StubModelValidator.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel.DataAnnotations;
 using HttPlaceholder.Application.Configuration;
 using HttPlaceholder.Common;
+using HttPlaceholder.Common.Utilities;
 using HttPlaceholder.Common.Validation;
 using HttPlaceholder.Domain;
 using Microsoft.Extensions.Options;
@@ -37,9 +38,8 @@ internal class StubModelValidator : IStubModelValidator
             result.Add($"Value for 'ExtraDuration' cannot be higher than '{allowedMillis}'.");
         }
 
-        // Validate scenario variables.
         ValidateScenarioVariables(stub, result);
-
+        ValidateResponseBody(stub, result);
         return result;
     }
 
@@ -96,6 +96,23 @@ internal class StubModelValidator : IStubModelValidator
         {
             validationErrors.Add(
                 "Scenario condition checkers and response writers can not be set if no 'scenario' is provided.");
+        }
+    }
+
+    private static void ValidateResponseBody(StubModel stub, ICollection<string> validationErrors)
+    {
+        var response = stub?.Response;
+        if (response == null)
+        {
+            return;
+        }
+
+        var count = StringHelper.CountNumberOfNonWhitespaceStrings(response.Text, response.Json, response.Xml,
+            response.Html, response.Base64, response.File);
+        if (count > 1)
+        {
+            validationErrors.Add(
+                "Only one of the response body fields (text, json, xml, html, base64, file) can be set");
         }
     }
 }

--- a/src/HttPlaceholder.Common.Tests/HttPlaceholder.Common.Tests.csproj
+++ b/src/HttPlaceholder.Common.Tests/HttPlaceholder.Common.Tests.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+        <PackageReference Include="Moq" Version="4.16.1" />
         <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
         <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
     </ItemGroup>

--- a/src/HttPlaceholder.Common.Tests/Utilities/ArgsHelperFacts.cs
+++ b/src/HttPlaceholder.Common.Tests/Utilities/ArgsHelperFacts.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.Generic;
+using HttPlaceholder.Common.Utilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HttPlaceholder.Common.Tests.Utilities;
+
+[TestClass]
+public class ArgsHelperFacts
+{
+    [TestMethod]
+    public void Parse_HappyFlow()
+    {
+        // Arrange
+        var args = GetArgs("--var1 value1 --var2 this is value 2");
+
+        // Act
+        var result = args.Parse();
+
+        // Assert
+        Assert.AreEqual(2, result.Count);
+        Assert.AreEqual("value1", result["var1"]);
+        Assert.AreEqual("this is value 2", result["var2"]);
+    }
+
+    [TestMethod]
+    public void EnsureEntryExists_EntryAlreadyExists_ShouldNotAddEntry()
+    {
+        // Arrange
+        var dict = new Dictionary<string, string> {{"var1", "value1"}};
+
+        // Act
+        dict.EnsureEntryExists("var1", "value2");
+
+        // Assert
+        Assert.AreEqual("value1", dict["var1"]);
+    }
+
+    [TestMethod]
+    public void EnsureEntryExists_EntryDoesNotExist_ShouldAddEntry()
+    {
+        // Arrange
+        var dict = new Dictionary<string, string> {{"var2", "value2"}};
+
+        // Act
+        dict.EnsureEntryExists("var1", "value1");
+
+        // Assert
+        Assert.AreEqual("value1", dict["var1"]);
+    }
+
+    private string[] GetArgs(string input) => input.Split(' ');
+}

--- a/src/HttPlaceholder.Common.Tests/Utilities/AutoMapperExtensionsFacts.cs
+++ b/src/HttPlaceholder.Common.Tests/Utilities/AutoMapperExtensionsFacts.cs
@@ -1,0 +1,33 @@
+﻿using AutoMapper;
+using HttPlaceholder.Common.Utilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace HttPlaceholder.Common.Tests.Utilities;
+
+[TestClass]
+public class AutoMapperExtensionsFacts
+{
+    [TestMethod]
+    public void MapAndSet_HappyFlow()
+    {
+        // Arrange
+        var mapperMock = new Mock<IMapper>();
+        var mappedModel = new TestModel();
+        var input = new object();
+        mapperMock
+            .Setup(m => m.Map<TestModel>(input))
+            .Returns(mappedModel);
+
+        // Act
+        var result = mapperMock.Object.MapAndSet<TestModel>(input, m => m.Value = "test123");
+
+        // Assert
+        Assert.AreEqual("test123", mappedModel.Value);
+    }
+
+    private class TestModel
+    {
+        public string Value { get; set; }
+    }
+}

--- a/src/HttPlaceholder.Common.Tests/Utilities/HashingUtilitiesFacts.cs
+++ b/src/HttPlaceholder.Common.Tests/Utilities/HashingUtilitiesFacts.cs
@@ -1,0 +1,36 @@
+﻿using HttPlaceholder.Common.Utilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HttPlaceholder.Common.Tests.Utilities;
+
+[TestClass]
+public class HashingUtilitiesFacts
+{
+    [TestMethod]
+    public void GetMd5String_HappyFlow()
+    {
+        // Arrange
+        var input = "test 123";
+        var expectedOutput = "39d0d586a701e199389d954f2d592720";
+
+        // Act
+        var result = HashingUtilities.GetMd5String(input);
+
+        // Assert
+        Assert.AreEqual(expectedOutput, result);
+    }
+
+    [TestMethod]
+    public void GetSha512String_HappyFlow()
+    {
+        // Arrange
+        var input = "test 123";
+        var expectedOutput = "RNiw9ZCfWvIt1SyjF8exd7hnDQHw8KK1iVcbqV+fyPt6yij3RnZkJS1SsuEmtxH4jjllJO4f3HK3Rjp0hKIcbw==";
+
+        // Act
+        var result = HashingUtilities.GetSha512String(input);
+
+        // Assert
+        Assert.AreEqual(expectedOutput, result);
+    }
+}

--- a/src/HttPlaceholder.Common.Tests/Utilities/StringHelperFacts.cs
+++ b/src/HttPlaceholder.Common.Tests/Utilities/StringHelperFacts.cs
@@ -1,0 +1,80 @@
+﻿using HttPlaceholder.Common.Utilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HttPlaceholder.Common.Tests.Utilities;
+
+[TestClass]
+public class StringHelperFacts
+{
+    [TestMethod]
+    public void IsRegexMatchOrSubstring_IsNotAMatch_ShouldReturnFalse()
+    {
+        // Arrange
+        var input = "input";
+        var regex = "input1";
+
+        // Act
+        var result = StringHelper.IsRegexMatchOrSubstring(input, regex);
+
+        // Assert
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public void IsRegexMatchOrSubstring_IsAMatch_ShouldReturnTrue()
+    {
+        // Arrange
+        var input = "input";
+        var regex = "input";
+
+        // Act
+        var result = StringHelper.IsRegexMatchOrSubstring(input, regex);
+
+        // Assert
+        Assert.IsTrue(result);
+    }
+
+    [DataTestMethod]
+    [DataRow("input-", "-", "input-")]
+    [DataRow("input", "-", "input-")]
+    public void EnsureEndsWith_HappyFlow(string input, string append, string expectedResult)
+    {
+        // Act
+        var result = input.EnsureEndsWith(append);
+
+        // Assert
+        Assert.AreEqual(expectedResult, result);
+    }
+
+    [DataTestMethod]
+    [DataRow("-input", "-", "-input")]
+    [DataRow("input", "-", "-input")]
+    public void EnsureStartsWith_HappyFlow(string input, string append, string expectedResult)
+    {
+        // Act
+        var result = input.EnsureStartsWith(append);
+
+        // Assert
+        Assert.AreEqual(expectedResult, result);
+    }
+
+    [TestMethod]
+    public void CountNumberOfNonWhitespaceStrings_NoInput_ShouldReturn0()
+    {
+        // Act
+        var result = StringHelper.CountNumberOfNonWhitespaceStrings();
+
+        // Assert
+        Assert.AreEqual(0, result);
+    }
+
+    [TestMethod]
+    public void CountNumberOfNonWhitespaceStrings_Input_ShouldReturnNumberOfNonWhitespaceOrNull()
+    {
+        // Act
+        var result = StringHelper.CountNumberOfNonWhitespaceStrings("", null, "input1", null, "input2");
+
+        // Assert
+        Assert.AreEqual(2, result);
+    }
+}

--- a/src/HttPlaceholder.Common.Tests/Utilities/XmlUtilitiesFacts.cs
+++ b/src/HttPlaceholder.Common.Tests/Utilities/XmlUtilitiesFacts.cs
@@ -1,0 +1,37 @@
+﻿using System.Xml;
+using HttPlaceholder.Common.Utilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HttPlaceholder.Common.Tests.Utilities;
+
+[TestClass]
+public class XmlUtilitiesFacts
+{
+    private const string Body = @"<?xml version=""1.0""?>
+<soap:Envelope xmlns:soap=""http://www.w3.org/2003/05/soap-envelope"" xmlns:m=""http://www.example.org/stock/Reddy"">
+  <soap:Header>
+  </soap:Header>
+  <soap:Body>
+    <m:GetStockPrice>
+      <m:StockName>Umbrella</m:StockName>
+      <m:Description>An umbrella</m:Description>
+    </m:GetStockPrice>
+  </soap:Body>
+</soap:Envelope>";
+
+    [TestMethod]
+    public void ParseBodyAndAssignNamespaces_HappyFlow()
+    {
+        // Arrange
+        var doc = new XmlDocument();
+        doc.LoadXml(Body);
+        var nsManager = new XmlNamespaceManager(doc.NameTable);
+
+        // Act
+        nsManager.ParseBodyAndAssignNamespaces(Body);
+
+        // Assert
+        Assert.AreEqual("http://www.w3.org/2003/05/soap-envelope", nsManager.LookupNamespace("soap"));
+        Assert.AreEqual("http://www.example.org/stock/Reddy", nsManager.LookupNamespace("m"));
+    }
+}

--- a/src/HttPlaceholder.Common.Tests/Utilities/YamlUtilitiesFacts.cs
+++ b/src/HttPlaceholder.Common.Tests/Utilities/YamlUtilitiesFacts.cs
@@ -1,0 +1,39 @@
+﻿using HttPlaceholder.Common.Utilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HttPlaceholder.Common.Tests.Utilities;
+
+[TestClass]
+public class YamlUtilitiesFacts
+{
+    [TestMethod]
+    public void Parse_HappyFlow()
+    {
+        // Arrange
+        const string yaml = "Value: val1";
+
+        // Act
+        var result = YamlUtilities.Parse<TestModel>(yaml);
+
+        // Assert
+        Assert.AreEqual("val1", result.Value);
+    }
+
+    [TestMethod]
+    public void Serialize_HappyFlow()
+    {
+        // Arrange
+        var input = new TestModel {Value = "val1"};
+
+        // Act
+        var result = YamlUtilities.Serialize(input);
+
+        // Assert
+        Assert.AreEqual("Value: val1\n", result);
+    }
+
+    private class TestModel
+    {
+        public string Value { get; set; }
+    }
+}

--- a/src/HttPlaceholder.Common/Utilities/StringHelper.cs
+++ b/src/HttPlaceholder.Common/Utilities/StringHelper.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace HttPlaceholder.Common.Utilities;
 
@@ -56,4 +57,12 @@ public static class StringHelper
 
         return input;
     }
+
+    /// <summary>
+    /// A method which receives a list of strings and returns the number of strings which are neither null or whitespace.
+    /// </summary>
+    /// <param name="strings">The list of strings.</param>
+    /// <returns>The number of instances where the string is neither null or whitespace.</returns>
+    public static int CountNumberOfNonWhitespaceStrings(params string[] strings) =>
+        strings.AsQueryable().Count(s => !string.IsNullOrWhiteSpace(s));
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

HttPlaceholder now checks if only 1 body response write is configured.

For example, this is allowed:

```yaml
id: stub-id
conditions:
  url:
    path: /path
response:
  text: OK!
```

But this is not:
```yaml
id: stub-id
conditions:
  url:
    path: /path
response:
  text: OK!
  json: {}
```

## Does this introduce a breaking change?

- [X] Yes
- [ ] No

Like described above, it is now not possible anymore to define more than 1 response writer. Before this, it would be useless to do this anyway because only 1 response body writer can be used, but it is now not possible anymore.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
