### PR TITLE
When updating a stub and the ID has not changed, do not delete the stub as this is pointless

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,7 @@
 - Added CSS spinner to show when asynchronous (HTTP) calls are working (https://github.com/dukeofharen/httplaceholder/pull/223).
 - Show validation error when stub response text is set and HTTP status code is 204 (https://github.com/dukeofharen/httplaceholder/pull/223).
 - Added fix so it is now possible to also send YAML to the API which contains fields that are not in the schema (https://github.com/dukeofharen/httplaceholder/pull/223).
+- When updating a stub and the ID has not changed, do not delete the stub as this is pointless (https://github.com/dukeofharen/httplaceholder/pull/225).
 
 # BREAKING CHANGES
 - As mentioned before, the "clean old requests" job is now enabled by default. If you want HttPlaceholder to continue cleaning requests in the old way, set `cleanOldRequestsInBackgroundJob` to `false` to not get a bigger bill on your serverless database than needed.

--- a/gui/src/components/stub/Stub.vue
+++ b/gui/src/components/stub/Stub.vue
@@ -57,8 +57,8 @@
               v-if="hasScenario"
               class="btn btn-success btn-sm me-2 btn-mobile"
               :to="{ name: 'ScenarioForm', params: { scenario: scenario } }"
-              >Set scenario</router-link
-            >
+              >Set scenario
+            </router-link>
             <button
               v-if="!isReadOnly"
               class="btn btn-danger btn-sm me-2 btn-mobile"
@@ -180,6 +180,14 @@ export default defineComponent({
           const enabled = await stubStore.flipEnabled(getStubId());
           fullStub.value.stub.enabled = enabled;
           overviewStubValue.value.stub.enabled = enabled;
+          let message;
+          if (enabled) {
+            message = resources.stubEnabledSuccessfully;
+          } else {
+            message = resources.stubDisabledSuccessfully;
+          }
+
+          success(message);
         } catch (e) {
           handleHttpError(e);
         }

--- a/gui/src/constants/resources.ts
+++ b/gui/src/constants/resources.ts
@@ -12,6 +12,8 @@ export const resources = {
   stubUpdatedSuccessfully: "Stub was updated successfully.",
   stubsDisabledSuccessfully: "Stubs were disabled successfully.",
   stubsEnabledSuccessfully: "Stubs were enabled successfully.",
+  stubEnabledSuccessfully: "Stub was enabled successfully.",
+  stubDisabledSuccessfully: "Stub was disabled successfully.",
   filteredStubsDeletedSuccessfully: "Stubs were deleted successfully.",
   stubNotFound: "Stub with ID %s was not found.",
   stubsInFileAddedSuccessfully: "Stubs in file '%s' were added successfully.",

--- a/src/HttPlaceholder.Application/Stubs/Commands/UpdateStubCommand/UpdateStubCommandHandler.cs
+++ b/src/HttPlaceholder.Application/Stubs/Commands/UpdateStubCommand/UpdateStubCommandHandler.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -47,9 +48,12 @@ public class UpdateStubCommandHandler : IRequestHandler<UpdateStubCommand>
             throw new ValidationException(string.Format(exceptionFormat, request.Stub.Id));
         }
 
-        // Delete stub with same ID.
-        await _stubContext.DeleteStubAsync(request.StubId);
-        await _stubContext.DeleteStubAsync(request.Stub.Id);
+        // Delete the stub if the ID has changed.
+        if (!string.Equals(request.StubId, request.Stub.Id, StringComparison.OrdinalIgnoreCase))
+        {
+            await _stubContext.DeleteStubAsync(request.StubId);
+            await _stubContext.DeleteStubAsync(request.Stub.Id);
+        }
 
         await _stubContext.AddStubAsync(request.Stub);
 

--- a/test/exec-tests.sh
+++ b/test/exec-tests.sh
@@ -22,21 +22,21 @@ sudo docker-compose -f "$DEVENV_SCRIPT_PATH" up -d
 
 # Run HttPlaceholder tests for in memory configuration.
 echo "Testing HttPlaceholder with in memory configuration"
-dotnet run -p $HTTPL_ROOT_DIR --useInMemoryStorage > $DIR/logs/httplaceholder-in-memory.txt 2>&1 &
+dotnet run --project $HTTPL_ROOT_DIR --useInMemoryStorage > $DIR/logs/httplaceholder-in-memory.txt 2>&1 &
 sleep 5
 newman run $POSTMAN_PATH --insecure > $DIR/logs/test-in-memory.txt
 assert-test-ok
 sudo killall HttPlaceholder
 
 # Run HttPlaceholder tests for in file storage configuration.
-echo "Testing HttPlaceholder with in file storage configuration"
+echo "Testing HttPlaceholder with file storage configuration"
 FILE_STORAGE_PATH="/tmp/httplaceholder_stubs"
 if [ ! -d "$FILE_STORAGE_PATH" ]; then
   echo "Creating folder $FILE_STORAGE_PATH"
   mkdir $FILE_STORAGE_PATH
 fi
 
-dotnet run -p $HTTPL_ROOT_DIR --fileStorageLocation $FILE_STORAGE_PATH > $DIR/logs/httplaceholder-file-storage.txt 2>&1 &
+dotnet run --project $HTTPL_ROOT_DIR --fileStorageLocation $FILE_STORAGE_PATH > $DIR/logs/httplaceholder-file-storage.txt 2>&1 &
 sleep 5
 newman run $POSTMAN_PATH --insecure > $DIR/logs/test-file-storage.txt
 assert-test-ok
@@ -49,7 +49,7 @@ if [ -f "$SQLITE_PATH" ]; then
   sudo rm $SQLITE_PATH
 fi
 
-dotnet run -p $HTTPL_ROOT_DIR --sqliteConnectionString "Data Source=$SQLITE_PATH" > $DIR/logs/httplaceholder-sqlite.txt 2>&1 &
+dotnet run --project $HTTPL_ROOT_DIR --sqliteConnectionString "Data Source=$SQLITE_PATH" > $DIR/logs/httplaceholder-sqlite.txt 2>&1 &
 sleep 5
 newman run $POSTMAN_PATH --insecure > $DIR/logs/test-sqlite.txt
 assert-test-ok
@@ -57,7 +57,7 @@ sudo killall HttPlaceholder
 
 # Run HttPlaceholder tests for in MySQL configuration.
 echo "Testing HttPlaceholder with in MySQL configuration"
-dotnet run -p $HTTPL_ROOT_DIR --mysqlConnectionString "Server=localhost;Database=httplaceholder;Uid=root;Pwd=root;Allow User Variables=true" > $DIR/logs/httplaceholder-mysql.txt 2>&1 &
+dotnet run --project $HTTPL_ROOT_DIR --mysqlConnectionString "Server=localhost;Database=httplaceholder;Uid=root;Pwd=root;Allow User Variables=true" > $DIR/logs/httplaceholder-mysql.txt 2>&1 &
 sleep 5
 newman run $POSTMAN_PATH --insecure > $DIR/logs/test-mysql.txt
 assert-test-ok
@@ -65,7 +65,7 @@ sudo killall HttPlaceholder
 
 # Run HttPlaceholder tests for in MSSQL configuration.
 echo "Testing HttPlaceholder with in MSSQL configuration"
-dotnet run -p $HTTPL_ROOT_DIR --sqlServerConnectionString "Server=localhost,1433;Database=httplaceholder;User Id=sa;Password=Password123!" > $DIR/logs/httplaceholder-mssql.txt 2>&1 &
+dotnet run --project $HTTPL_ROOT_DIR --sqlServerConnectionString "Server=localhost,1433;Database=httplaceholder;User Id=sa;Password=Password123!" > $DIR/logs/httplaceholder-mssql.txt 2>&1 &
 sleep 5
 newman run $POSTMAN_PATH --insecure > $DIR/logs/test-mssql.txt
 assert-test-ok


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

When updating a stub through the API, the stub is deleted and added again. When the ID has not been updated, the stub should not be deleted beforehand as this is pointless.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
