### PR TITLE
Fixed indenting issue in Codemirror editor

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,6 +22,7 @@
 - Show validation error when stub response text is set and HTTP status code is 204 (https://github.com/dukeofharen/httplaceholder/pull/223).
 - Added fix so it is now possible to also send YAML to the API which contains fields that are not in the schema (https://github.com/dukeofharen/httplaceholder/pull/223).
 - When updating a stub and the ID has not changed, do not delete the stub as this is pointless (https://github.com/dukeofharen/httplaceholder/pull/225).
+- Fixed indenting issue in CodeMirror editor (https://github.com/dukeofharen/httplaceholder/pull/226).
 
 # BREAKING CHANGES
 - As mentioned before, the "clean old requests" job is now enabled by default. If you want HttPlaceholder to continue cleaning requests in the old way, set `cleanOldRequestsInBackgroundJob` to `false` to not get a bigger bill on your serverless database than needed.

--- a/gui/src/components/codemirror/CodeMirror.vue
+++ b/gui/src/components/codemirror/CodeMirror.vue
@@ -41,10 +41,19 @@ export default defineComponent({
         );
         cmInstance.setOption("extraKeys", {
           Tab: (cm) => {
-            // Make sure inserts spaces instead of tabs.
-            const currentIndent = cm.getOption("indentUnit") || 0;
-            const spaces = Array(currentIndent + 1).join(" ");
-            cm.replaceSelection(spaces);
+            if (cm.somethingSelected()) {
+              cm.indentSelection("add");
+            } else {
+              // Make sure inserts spaces instead of tabs.
+              const currentIndent = cm.getOption("indentUnit") || 0;
+              const spaces = Array(currentIndent + 1).join(" ");
+              cm.replaceSelection(spaces);
+            }
+          },
+          "Shift-Tab": (cm) => {
+            if (cm.somethingSelected()) {
+              cm.indentSelection("subtract");
+            }
           },
         });
         if (generalStore.getDarkTheme) {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

- When something is selected in the CodeMirror editor in the UI and tab is pressed, the selection is indented instead of replaced by a few spaces.
- Also, when a selection is made and "Shift + Tab" is pressed, the indentation is reversed.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
