### PR TITLE
Refactoring/versioning fix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,6 +11,7 @@ stages:
   - build-ui
   - build-server
   - build-docs
+  - pre-publish
   - publish
 
 set-version:
@@ -124,6 +125,14 @@ create-nuget-client-docs:
     paths:
       - dist
     expire_in: 1 week
+
+pre-publish-check:
+  image: $DEBIAN_IMAGE
+  stage: pre-publish
+  when: manual
+  script:
+    - chmod +x ./scripts/build/pre-publish-check.sh
+    - ./scripts/build/pre-publish-check.sh
 
 docker-build:
   image: $DOCKER_IMAGE

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-[1.4.4]
+[vnext]
 - Clear form helper filter if form helper is selected (https://github.com/dukeofharen/httplaceholder/pull/248).
 
 # BREAKING CHANGES

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
-[vnext]
+[2022.6.11]
 - Clear form helper filter if form helper is selected (https://github.com/dukeofharen/httplaceholder/pull/248).
+- Changed versioning again (to a format that `dotnet tool` accepts) (https://github.com/dukeofharen/httplaceholder/pull/249).
 
 # BREAKING CHANGES
 - 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Run the following command to run a basic HttPlaceholder container: `docker run -
 **Install as .NET tool**
 
 ```bash
-dotnet tool install --global HttPlaceholder --version "1.*"
+dotnet tool install --global HttPlaceholder
 ```
 
 ### Example

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -96,7 +96,7 @@ Follow these steps to install / update HttPlaceholder. If you update HttPlacehol
 
 ## Dotnet global tool (cross platform)
 
-Make sure you have installed the correct .NET SDK (at least .NET 6) for your OS (see https://dotnet.microsoft.com/download). When the .NET SDK is installed, run `dotnet tool install --global HttPlaceholder --version "1.*"` to install HttPlaceholder.
+Make sure you have installed the correct .NET SDK (at least .NET 6) for your OS (see https://dotnet.microsoft.com/download). When the .NET SDK is installed, run `dotnet tool install --global HttPlaceholder` to install HttPlaceholder.
 
 ## Windows
 

--- a/scripts/build/pre-publish-check.sh
+++ b/scripts/build/pre-publish-check.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+ROOT_FOLDER="$DIR/../.."
+CHANGELOG_PATH="$ROOT_FOLDER/CHANGELOG"
+BASE_VERSION=$(head -n 1 $CHANGELOG_PATH | sed 's/\[//' | sed 's/\]//')
+if [ "$BASE_VERSION" = "vnext" ]; then
+  echo "Version as set in $CHANGELOG_PATH is still 'vnext'. Please change it to a correct version"
+  exit 1
+fi
+
+echo "Version $BASE_VERSION is correct; continuing..."

--- a/scripts/build/set-version.sh
+++ b/scripts/build/set-version.sh
@@ -14,6 +14,10 @@ CHANGELOG_PATH="$ROOT_FOLDER/CHANGELOG"
 
 echo "Determining version"
 BASE_VERSION=$(head -n 1 $CHANGELOG_PATH | sed 's/\[//' | sed 's/\]//')
+if [ "$BASE_VERSION" = "vnext" ]; then
+  BASE_VERSION=$(date +"%Y.%-m.%-d")
+fi
+
 VERSION="$BASE_VERSION.$1"
 echo "Version is $VERSION"
 echo "$VERSION" > "$ROOT_FOLDER/version.txt"


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

Last year November, I decided to change the versioning format of HttPlaceholder fom date (so `2021.11.1.123`) to regular semver (so `1.4.3.123`). This seemed to work, but the HttPlaceholder .NET tool does not like this version update (and should not have happened in the first place. This PR changes the versioning back to date format, but takes the date from the CHANGELOG file instead of calculating it on the spot.

## Does this introduce a breaking change?

- [X] Yes
- [ ] No

Yes, the versioning will be different, but new versions from now on will be in correct semver format.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
