### PR TITLE
Fixed bug in deserialization of HAR

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 [vnext]
 - If stub is executed, return "X-HttPlaceholder-ExecutedStub" header with stub ID (https://github.com/dukeofharen/httplaceholder/pull/269).
 - Show the configuration as "read only" values in the user interface (https://github.com/dukeofharen/httplaceholder/issues/261).
+- Fixed bug where "headersSize" in "request" in HAR can not be null (https://github.com/dukeofharen/httplaceholder/issues/271).
 
 [2022.9.3]
 - Fixed link to API docs (https://github.com/dukeofharen/httplaceholder/pull/256).

--- a/src/HttPlaceholder.Application/StubExecution/Models/HAR/Request.cs
+++ b/src/HttPlaceholder.Application/StubExecution/Models/HAR/Request.cs
@@ -53,7 +53,7 @@ public class Request
     /// Gets or sets headers size.
     /// </summary>
     [JsonProperty("headersSize")]
-    public int HeadersSize { get; set; }
+    public int? HeadersSize { get; set; }
 
     /// <summary>
     /// Gets or sets body size.

--- a/src/HttPlaceholder.Application/StubExecution/Models/HAR/Response.cs
+++ b/src/HttPlaceholder.Application/StubExecution/Models/HAR/Response.cs
@@ -53,7 +53,7 @@ public class Response
     /// Gets or sets headers size.
     /// </summary>
     [JsonProperty("headersSize")]
-    public int HeadersSize { get; set; }
+    public int? HeadersSize { get; set; }
 
     /// <summary>
     /// Gets or sets property.

--- a/src/HttPlaceholder.Tests/Integration/RestApi/RestApiImportHarTests.cs
+++ b/src/HttPlaceholder.Tests/Integration/RestApi/RestApiImportHarTests.cs
@@ -112,4 +112,28 @@ public class RestApiImportHarTests : RestApiIntegrationTestBase
         Assert.AreEqual("nginx", stub.Response.Headers["server"]);
         Assert.AreEqual(string.Empty, stub.Response.Text);
     }
+
+    [TestMethod]
+    public async Task RestApiIntegration_Import_ImportHar_RequestHeaderSizeIsNull_ShouldWork()
+    {
+        // Arrange
+        var content = await File.ReadAllTextAsync("Resources/har_headerssize_null.txt");
+
+        // Post HAR to API.
+        var url = $"{BaseAddress}ph-api/import/har?doNotCreateStub=false&tenant=tenant1";
+        var apiRequest = new HttpRequestMessage
+        {
+            RequestUri = new Uri(url),
+            Method = HttpMethod.Post,
+            Content = new StringContent(content, Encoding.UTF8, Constants.TextMime)
+        };
+        var harResponse = await Client.SendAsync(apiRequest);
+        harResponse.EnsureSuccessStatusCode();
+
+        // Get and check the stubs.
+        var stubs = StubSource.StubModels.ToArray();
+
+        // Assert stubs.
+        Assert.AreEqual(1, stubs.Length);
+    }
 }

--- a/src/HttPlaceholder.Tests/Resources/har_headerssize_null.txt
+++ b/src/HttPlaceholder.Tests/Resources/har_headerssize_null.txt
@@ -1,0 +1,171 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "WebInspector",
+      "version": "537.36"
+    },
+    "pages": [
+      {
+        "startedDateTime": "2021-12-28T10:27:47.140Z",
+        "id": "page_2",
+        "title": "https://ducode.org/",
+        "pageTimings": {
+          "onContentLoad": 85.7560000004014,
+          "onLoad": 117.96900000081223
+        }
+      }
+    ],
+    "entries": [
+      {
+        "_initiator": {
+          "type": "other"
+        },
+        "_priority": "VeryHigh",
+        "_resourceType": "document",
+        "cache": {},
+        "connection": "1461",
+        "pageref": "page_2",
+        "request": {
+          "method": "GET",
+          "url": "https://ducode.org/",
+          "httpVersion": "http/2.0",
+          "headers": [
+            {
+              "name": ":method",
+              "value": "GET"
+            },
+            {
+              "name": ":authority",
+              "value": "ducode.org"
+            },
+            {
+              "name": ":scheme",
+              "value": "https"
+            },
+            {
+              "name": ":path",
+              "value": "/"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\" Not A;Brand\";v=\"99\", \"Chromium\";v=\"96\""
+            },
+            {
+              "name": "sec-ch-ua-mobile",
+              "value": "?0"
+            },
+            {
+              "name": "sec-ch-ua-platform",
+              "value": "\"Linux\""
+            },
+            {
+              "name": "upgrade-insecure-requests",
+              "value": "1"
+            },
+            {
+              "name": "user-agent",
+              "value": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.36"
+            },
+            {
+              "name": "accept",
+              "value": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"
+            },
+            {
+              "name": "sec-fetch-site",
+              "value": "none"
+            },
+            {
+              "name": "sec-fetch-mode",
+              "value": "navigate"
+            },
+            {
+              "name": "sec-fetch-user",
+              "value": "?1"
+            },
+            {
+              "name": "sec-fetch-dest",
+              "value": "document"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate, br"
+            },
+            {
+              "name": "accept-language",
+              "value": "en-US,en;q=0.9"
+            }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": null,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "",
+          "httpVersion": "http/2.0",
+          "headers": [
+            {
+              "name": "server",
+              "value": "nginx"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 28 Dec 2021 10:27:47 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "text/html"
+            },
+            {
+              "name": "last-modified",
+              "value": "Fri, 24 Dec 2021 08:58:27 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"61c58bb3-cd3\""
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 3283,
+            "mimeType": "text/html",
+            "text": "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n    <meta charset=\"utf-8\"/>\n    <meta name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <link rel=\"canonical\" href=\"https://ducode.org\"/>\n    <link rel=\"stylesheet\" type=\"text/css\" href=\"https://ducode.org/static/style/style.css\"/>\n    <link rel=\"shortcut icon\" type=\"image/png\" href=\"https://ducode.org/static/favicon.png\"/>\n    <link rel=\"alternate\" type=\"application/rss+xml\" title=\"Duco's blog\" href=\"https://ducode.org/feed.xml\" />\n\n    <title>Ducode.org - Duco: (web) developer from NL</title>\n</head>\n<body>\n<div class=\"portfolio\">\n    <p>\n        Duco, Netherlands based (web) developer, currently working for\n        <a href=\"https://quintor.nl\">Quintor</a>. Many years of experience in the .NET stack (ASP.NET (Core), SQL\n        Server, Windows etc.), frontend development (Vue, Angular, HTML etc.) and is currently mastering the Java stack\n        (Spring Boot).\n    </p>\n    <h1>&gt; blog</h1>\n\n    <h2><a href=\"https://ducode.org/posts/dell-xps-15-9510-ubuntu-20-04-docking-station\">Dell XPS 15 9510 + Ubuntu 20.04 + Docking station</a> (Dec 23 &#39;21)</h2>\n    <h2><a href=\"https://ducode.org/posts/this-week-i-learnt-week-37\">This Week I Learnt: week 37 2019</a> (Sep 16 &#39;19)</h2>\n    <h2><a href=\"https://ducode.org/posts/ubuntu-18-04-unable-to-log-in\">Ubuntu 18.04: unable to log in after locking PC</a> (Sep 08 &#39;19)</h2>\n    <h2><a href=\"https://ducode.org/posts/git-submodules\">Git Submodules</a> (Jan 02 &#39;19)</h2>\n    <h2><a href=\"https://ducode.org/posts/windows-tools\">Windows Tools</a> (Jul 06 &#39;18)</h2>\n    <h2><a href=\"https://ducode.org/posts\">More posts</a></h2>\n\n    <h1>&gt; projects</h1>\n    <div>\n        <h2><a href=\"https://httplaceholder.com\">HttPlaceholder</a> (active)</h2>\n        <p>HTTP stub application for easily stubbing away any kind of HTTP call.</p>\n    </div>\n    <div>\n        <h2><a href=\"https://armyknife.net\">Armyknife</a> (active)</h2>\n        <p>Website with all kinds of handy (developer related) tools.</p>\n    </div>\n    <div>\n        <h2><a href=\"https://budgetkar.nl\">Budgetkar</a> (active)</h2>\n        <p>Netherlands based company where customers can rent trailers.</p>\n    </div>\n    <div>\n        <h2><a href=\"https://github.com/dukeofharen/armyknife\">Armyknife console app</a> (inactive)</h2>\n        <p>The old Armyknife, which came in a console app. Still works, but not actively developed.</p>\n    </div>\n    <div>\n        <h2><a href=\"https://github.com/dukeofharen/iforgot\">IForgot</a> (inactive)</h2>\n        <p>Simple console app for Windows which takes a screenshot every x seconds of all your screens. Still works, but\n            not\n            actively developed.</p>\n    </div>\n    <div>\n        <h2><a href=\"https://github.com/dukeofharen/wolk\">Wolk</a> (inactive)</h2>\n        <p>Self-hosted web application for taking notes, todo items etc. Still works, but not actively developed.</p>\n    </div>\n    <h1>&gt; get in touch</h1>\n    <p>\n        <a href=\"mailto:blog@ducode.org\">mail</a><br/>\n        <a href=\"https://github.com/dukeofharen\">github</a><br/>\n        <a href=\"https://twitter.com/ducodotnet\">twitter</a><br/>\n        <a href=\"https://www.linkedin.com/in/ducowinterwerp/\">linkedin</a>\n    </p>\n</div>\n</body>\n</html>\n"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": -1,
+          "_transferSize": 1438,
+          "_error": null
+        },
+        "serverIPAddress": "136.144.216.39",
+        "startedDateTime": "2021-12-28T10:27:47.139Z",
+        "time": 98.84800000031291,
+        "timings": {
+          "blocked": 2.4049999993901,
+          "dns": 20.937,
+          "ssl": 20.309999999999995,
+          "connect": 59.435,
+          "send": 0.11399999999999721,
+          "wait": 15.270999999698951,
+          "receive": 0.6860000012238743,
+          "_blocked_queueing": 0.9169999993901001,
+          "_blocked_proxy": 0.9500000000000001
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

You can create stubs based on an HTTP archive (or HAR for short). When downloading a HAR from Firefox, the "headersSize" element of "request" was null, which resulted in an exception.

## What is the new behavior?

The field "headersSize" is now optional.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
