### PR TITLE
HttPlaceholder creates a lot of Inotify watches when starting the application

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 - Log application startup time (https://github.com/dukeofharen/httplaceholder/pull/285).
 - Make it possible to update settings through API (only "storeResponses" for now) (https://github.com/dukeofharen/httplaceholder/pull/286).
 - Added option to set "storeResponses" in UI (https://github.com/dukeofharen/httplaceholder/pull/286).
+- Fixed bug where a lot of file watches were placed which were not necessary (https://github.com/dukeofharen/httplaceholder/pull/289).
 
 # BREAKING CHANGES
 - Stubs defined in a .yml file should ALWAYS have an id field defined, whereas it was automatically generated beforehand if it was not set (which caused some non stub files to get parsed as stub with weird behavior).

--- a/src/.run/HttPlaceholder (in-memory).run.xml
+++ b/src/.run/HttPlaceholder (in-memory).run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="HttPlaceholder (in-memory)" type="DotNetProject" factoryName=".NET Project">
     <option name="EXE_PATH" value="$PROJECT_DIR$/HttPlaceholder/bin/Debug/net6.0/HttPlaceholder" />
-    <option name="PROGRAM_PARAMETERS" value="-V --useInMemoryStorage --storeresponses" />
+    <option name="PROGRAM_PARAMETERS" value="-V --useInMemoryStorage --storeresponses --port &quot;5000,5002&quot; --httpsPort &quot;5050,5056&quot;" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/HttPlaceholder" />
     <option name="PASS_PARENT_ENVS" value="1" />
     <option name="USE_EXTERNAL_CONSOLE" value="0" />

--- a/src/HttPlaceholder.Common/ITcpService.cs
+++ b/src/HttPlaceholder.Common/ITcpService.cs
@@ -1,0 +1,20 @@
+﻿namespace HttPlaceholder.Common;
+
+/// <summary>
+///     Describes a utility class for working with TCP connections.
+/// </summary>
+public interface ITcpService
+{
+    /// <summary>
+    ///     Checks whether a given port was taken.
+    /// </summary>
+    /// <param name="port">The port to check.</param>
+    /// <returns>True if the port was taken, false otherwise.</returns>
+    bool PortIsTaken(int port);
+
+    /// <summary>
+    ///     Gets a free TCP port.
+    /// </summary>
+    /// <returns>The free TCP port.</returns>
+    int GetNextFreeTcpPort();
+}

--- a/src/HttPlaceholder.Infrastructure/Implementations/TcpService.cs
+++ b/src/HttPlaceholder.Infrastructure/Implementations/TcpService.cs
@@ -1,0 +1,17 @@
+﻿using HttPlaceholder.Application.Infrastructure.DependencyInjection;
+using HttPlaceholder.Common;
+using HttPlaceholder.Common.Utilities;
+
+namespace HttPlaceholder.Infrastructure.Implementations;
+
+/// <summary>
+///     A utility class for working with TCP connections.
+/// </summary>
+public class TcpService : ITcpService, ISingletonService
+{
+    /// <inheritdoc />
+    public bool PortIsTaken(int port) => TcpUtilities.PortIsTaken(port);
+
+    /// <inheritdoc />
+    public int GetNextFreeTcpPort() => TcpUtilities.GetNextFreeTcpPort();
+}

--- a/src/HttPlaceholder.Tests/Utilities/ProgramUtilityFacts.cs
+++ b/src/HttPlaceholder.Tests/Utilities/ProgramUtilityFacts.cs
@@ -56,12 +56,15 @@ public class ProgramUtilityFacts
         _mockTcp
             .Setup(m => m.PortIsTaken(7000))
             .Returns(true);
+        _mockTcp
+            .Setup(m => m.PortIsTaken(7001))
+            .Returns(true);
 
         // Act
         var exception = Assert.ThrowsException<ArgumentException>(() => _utility.GetPorts(_settings));
 
         // Assert
-        Assert.AreEqual("Port '7000' is already taken.", exception.Message);
+        Assert.AreEqual("The following ports are already taken: 7000, 7001", exception.Message);
     }
 
     [TestMethod]
@@ -116,12 +119,15 @@ public class ProgramUtilityFacts
         _mockTcp
             .Setup(m => m.PortIsTaken(7000))
             .Returns(true);
+        _mockTcp
+            .Setup(m => m.PortIsTaken(7001))
+            .Returns(true);
 
         // Act
         var exception = Assert.ThrowsException<ArgumentException>(() => _utility.GetPorts(_settings));
 
         // Assert
-        Assert.AreEqual("Port '7000' is already taken.", exception.Message);
+        Assert.AreEqual("The following ports are already taken: 7000, 7001", exception.Message);
     }
 
     [TestMethod]

--- a/src/HttPlaceholder.Tests/Utilities/ProgramUtilityFacts.cs
+++ b/src/HttPlaceholder.Tests/Utilities/ProgramUtilityFacts.cs
@@ -1,0 +1,220 @@
+﻿using System.Linq;
+using HttPlaceholder.Application.Configuration;
+using HttPlaceholder.Common;
+using HttPlaceholder.Utilities.Implementations;
+
+namespace HttPlaceholder.Tests.Utilities;
+
+[TestClass]
+public class ProgramUtilityFacts
+{
+    private readonly Mock<ITcpService> _mockTcp = new();
+    private readonly SettingsModel _settings = MockSettingsFactory.GetSettings();
+    private ProgramUtility _utility;
+
+    [TestInitialize]
+    public void Initialize()
+    {
+        _settings.Web.HttpPort = DefaultConfiguration.DefaultHttpPort.ToString();
+        _settings.Web.HttpsPort = DefaultConfiguration.DefaultHttpsPort.ToString();
+        _settings.Web.UseHttps = true;
+        _settings.Web.PfxPath = "/etc/key.pfx";
+        _settings.Web.PfxPassword = "1234";
+        _utility = new ProgramUtility(_mockTcp.Object);
+    }
+
+    [TestCleanup]
+    public void Cleanup() => _mockTcp.VerifyAll();
+
+    [TestMethod]
+    public void GetPorts_Http_DefaultPortTaken_ShouldTakeNextFreePort()
+    {
+        // Arrange
+        _mockTcp
+            .Setup(m => m.PortIsTaken(DefaultConfiguration.DefaultHttpPort))
+            .Returns(true);
+
+        const int nextFreePort = 6000;
+        _mockTcp
+            .Setup(m => m.GetNextFreeTcpPort())
+            .Returns(nextFreePort);
+
+        // Act
+        var result = _utility.GetPorts(_settings);
+
+        // Assert
+        var httpPorts = result.httpPorts.ToArray();
+        Assert.AreEqual(1, httpPorts.Length);
+        Assert.AreEqual(nextFreePort, httpPorts[0]);
+    }
+
+    [TestMethod]
+    public void GetPorts_Http_NonDefaultPort_PortIsTaken_ShouldThrowException()
+    {
+        // Arrange
+        _settings.Web.HttpPort = "7000,7001";
+        _mockTcp
+            .Setup(m => m.PortIsTaken(7000))
+            .Returns(true);
+
+        // Act
+        var exception = Assert.ThrowsException<ArgumentException>(() => _utility.GetPorts(_settings));
+
+        // Assert
+        Assert.AreEqual("Port '7000' is already taken.", exception.Message);
+    }
+
+    [TestMethod]
+    public void GetPorts_Http_NonDefaultPort_PortsAreNotTaken_ShouldReturnPorts()
+    {
+        // Arrange
+        _settings.Web.HttpPort = "7000,7001";
+        _mockTcp
+            .Setup(m => m.PortIsTaken(7000))
+            .Returns(false);
+        _mockTcp
+            .Setup(m => m.PortIsTaken(7001))
+            .Returns(false);
+
+        // Act
+        var result = _utility.GetPorts(_settings);
+
+        // Assert
+        var httpPorts = result.httpPorts.ToArray();
+        Assert.AreEqual(2, httpPorts.Length);
+        Assert.AreEqual(7000, httpPorts[0]);
+        Assert.AreEqual(7001, httpPorts[1]);
+    }
+
+    [TestMethod]
+    public void GetPorts_Https_DefaultPortTaken_ShouldTakeNextFreePort()
+    {
+        // Arrange
+        _mockTcp
+            .Setup(m => m.PortIsTaken(DefaultConfiguration.DefaultHttpsPort))
+            .Returns(true);
+
+        const int nextFreePort = 6000;
+        _mockTcp
+            .Setup(m => m.GetNextFreeTcpPort())
+            .Returns(nextFreePort);
+
+        // Act
+        var result = _utility.GetPorts(_settings);
+
+        // Assert
+        var httpsPorts = result.httpsPorts.ToArray();
+        Assert.AreEqual(1, httpsPorts.Length);
+        Assert.AreEqual(nextFreePort, httpsPorts[0]);
+    }
+
+    [TestMethod]
+    public void GetPorts_Https_NonDefaultPort_PortIsTaken_ShouldThrowException()
+    {
+        // Arrange
+        _settings.Web.HttpsPort = "7000,7001";
+        _mockTcp
+            .Setup(m => m.PortIsTaken(7000))
+            .Returns(true);
+
+        // Act
+        var exception = Assert.ThrowsException<ArgumentException>(() => _utility.GetPorts(_settings));
+
+        // Assert
+        Assert.AreEqual("Port '7000' is already taken.", exception.Message);
+    }
+
+    [TestMethod]
+    public void GetPorts_Https_NonDefaultPort_PortsAreNotTaken_ShouldReturnPorts()
+    {
+        // Arrange
+        _settings.Web.HttpsPort = "7000,7001";
+        _mockTcp
+            .Setup(m => m.PortIsTaken(7000))
+            .Returns(false);
+        _mockTcp
+            .Setup(m => m.PortIsTaken(7001))
+            .Returns(false);
+
+        // Act
+        var result = _utility.GetPorts(_settings);
+
+        // Assert
+        var httpsPorts = result.httpsPorts.ToArray();
+        Assert.AreEqual(2, httpsPorts.Length);
+        Assert.AreEqual(7000, httpsPorts[0]);
+        Assert.AreEqual(7001, httpsPorts[1]);
+    }
+
+    [TestMethod]
+    public void GetPorts_Https_UseHttpsIsFalse_ShouldNotParseHttpsPorts()
+    {
+        // Arrange
+        _settings.Web.HttpsPort = "7000,7001";
+        _settings.Web.UseHttps = false;
+
+        // Act
+        var result = _utility.GetPorts(_settings);
+
+        // Assert
+        Assert.AreEqual(0, result.httpsPorts.Count());
+    }
+
+    [TestMethod]
+    public void GetPorts_Https_PfxPathNotSet_ShouldNotParseHttpsPorts()
+    {
+        // Arrange
+        _settings.Web.HttpsPort = "7000,7001";
+        _settings.Web.PfxPath = string.Empty;
+
+        // Act
+        var result = _utility.GetPorts(_settings);
+
+        // Assert
+        Assert.AreEqual(0, result.httpsPorts.Count());
+    }
+
+    [TestMethod]
+    public void GetPorts_Https_PfxPasswordNotSet_ShouldNotParseHttpsPorts()
+    {
+        // Arrange
+        _settings.Web.HttpsPort = "7000,7001";
+        _settings.Web.PfxPassword = string.Empty;
+
+        // Act
+        var result = _utility.GetPorts(_settings);
+
+        // Assert
+        Assert.AreEqual(0, result.httpsPorts.Count());
+    }
+
+    [DataTestMethod]
+    [DataRow(false, "0", "Port '0' is invalid.")]
+    [DataRow(false, "65536", "Port '65536' is invalid.")]
+    [DataRow(false, "hi", "Port 'hi' is invalid.")]
+    [DataRow(false, "80,hi", "Port 'hi' is invalid.")]
+    [DataRow(false, "80, 65536", "Port '65536' is invalid.")]
+    [DataRow(true, "0", "Port '0' is invalid.")]
+    [DataRow(true, "65536", "Port '65536' is invalid.")]
+    [DataRow(true, "hi", "Port 'hi' is invalid.")]
+    [DataRow(true, "80,hi", "Port 'hi' is invalid.")]
+    [DataRow(true, "80, 65536", "Port '65536' is invalid.")]
+    public void GetPorts_PortIsInvalid(bool isHttps, string port, string expectedError)
+    {
+        // Arrange
+        if (isHttps)
+        {
+            _settings.Web.HttpPort = port;
+        }
+        else
+        {
+            _settings.Web.HttpsPort = port;
+        }
+
+        // Act
+        var exception = Assert.ThrowsException<ArgumentException>(() => _utility.GetPorts(_settings));
+
+        // Assert
+        Assert.AreEqual(expectedError, exception.Message);
+    }
+}

--- a/src/HttPlaceholder/Utilities/HostBuilderUtilities.cs
+++ b/src/HttPlaceholder/Utilities/HostBuilderUtilities.cs
@@ -7,20 +7,21 @@ using Microsoft.Extensions.Logging.EventLog;
 namespace HttPlaceholder.Utilities;
 
 /// <summary>
-/// TODO
+///     A class that contains methods for creating a host builder.
 /// </summary>
 public static class HostBuilderUtilities
 {
     /// <summary>
-    /// TODO
+    ///     Creates a <see cref="IHostBuilder"/> specifically for HttPlaceholder.
+    ///     One of the problems we had is that when using the default host builder,
+    ///     .NET creates a lot of unnecessary Inotify watches.
     /// </summary>
-    /// <returns></returns>
     public static IHostBuilder CreateHostBuilder()
     {
         var builder = new HostBuilder();
         builder.UseContentRoot(Directory.GetCurrentDirectory());
         builder
-            .ConfigureLogging((hostingContext, logging) =>
+            .ConfigureLogging((_, logging) =>
             {
                 var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
                 if (isWindows)

--- a/src/HttPlaceholder/Utilities/HostBuilderUtilities.cs
+++ b/src/HttPlaceholder/Utilities/HostBuilderUtilities.cs
@@ -1,0 +1,46 @@
+﻿using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.EventLog;
+
+namespace HttPlaceholder.Utilities;
+
+/// <summary>
+/// TODO
+/// </summary>
+public static class HostBuilderUtilities
+{
+    /// <summary>
+    /// TODO
+    /// </summary>
+    /// <returns></returns>
+    public static IHostBuilder CreateHostBuilder()
+    {
+        var builder = new HostBuilder();
+        builder.UseContentRoot(Directory.GetCurrentDirectory());
+        builder
+            .ConfigureLogging((hostingContext, logging) =>
+            {
+                var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+                if (isWindows)
+                {
+                    logging.AddFilter<EventLogLoggerProvider>(level => level >= LogLevel.Warning);
+                }
+
+                logging.AddDebug();
+                logging.AddEventSourceLogger();
+                if (isWindows)
+                {
+                    logging.AddEventLog();
+                }
+            })
+            .UseDefaultServiceProvider((context, options) =>
+            {
+                var isDevelopment = context.HostingEnvironment.IsDevelopment();
+                options.ValidateScopes = isDevelopment;
+                options.ValidateOnBuild = isDevelopment;
+            });
+        return builder;
+    }
+}

--- a/src/HttPlaceholder/Utilities/IProgramUtility.cs
+++ b/src/HttPlaceholder/Utilities/IProgramUtility.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using HttPlaceholder.Application.Configuration;
+
+namespace HttPlaceholder.Utilities;
+
+/// <summary>
+///     Describes a class that is used to help start up HttPlaceholder.
+/// </summary>
+public interface IProgramUtility
+{
+    /// <summary>
+    ///     Parses the HTTP and HTTPS ports from the settings and returns both HTTP and HTTPS ports as a arrays.
+    /// </summary>
+    /// <param name="settings">The settings.</param>
+    /// <returns>A tuple containing lists with HTTP and HTTPS ports.</returns>
+    (IEnumerable<int> httpPorts, IEnumerable<int> httpsPorts) GetPorts(SettingsModel settings);
+}

--- a/src/HttPlaceholder/Utilities/Implementations/ProgramUtility.cs
+++ b/src/HttPlaceholder/Utilities/Implementations/ProgramUtility.cs
@@ -45,6 +45,7 @@ public class ProgramUtility : IProgramUtility
         else
         {
             httpPortsResult.AddRange(httpPorts);
+            EnsureNoPortsAreTaken(httpPorts);
         }
 
         if (settings.Web.UseHttps && !string.IsNullOrWhiteSpace(settings.Web.PfxPath) &&
@@ -59,6 +60,7 @@ public class ProgramUtility : IProgramUtility
             else
             {
                 httpsPortsResult.AddRange(httpsPorts);
+                EnsureNoPortsAreTaken(httpsPorts);
             }
         }
 
@@ -80,5 +82,14 @@ public class ProgramUtility : IProgramUtility
         }
 
         return result.ToArray();
+    }
+
+    private void EnsureNoPortsAreTaken(IEnumerable<int> ports)
+    {
+        var portsTaken = ports.Where(p => _tcpService.PortIsTaken(p)).ToArray();
+        if (portsTaken.Any())
+        {
+            throw new ArgumentException($"The following ports are already taken: {string.Join(", ", portsTaken)}");
+        }
     }
 }

--- a/src/HttPlaceholder/Utilities/Implementations/ProgramUtility.cs
+++ b/src/HttPlaceholder/Utilities/Implementations/ProgramUtility.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using HttPlaceholder.Application.Configuration;
+using HttPlaceholder.Common;
+using HttPlaceholder.Domain;
+using HttPlaceholder.Infrastructure.Implementations;
+
+namespace HttPlaceholder.Utilities.Implementations;
+
+/// <summary>
+///     A class that is used to help start up HttPlaceholder.
+/// </summary>
+public class ProgramUtility : IProgramUtility
+{
+    private readonly ITcpService _tcpService;
+
+    /// <summary>
+    ///     Constructs a <see cref="ProgramUtility"/> instance.
+    /// </summary>
+    public ProgramUtility() : this(new TcpService())
+    {
+    }
+
+    /// <summary>
+    ///     Constructs a <see cref="ProgramUtility"/> instance.
+    /// </summary>
+    private ProgramUtility(ITcpService tcpService)
+    {
+        _tcpService = tcpService;
+    }
+
+    /// <inheritdoc />
+    public (IEnumerable<int> httpPorts, IEnumerable<int> httpsPorts) GetPorts(SettingsModel settings)
+    {
+        var httpPortsResult = new List<int>();
+        var httpsPortsResult = new List<int>();
+
+        // TODO combine these 2 blocks?
+        var httpPorts = ParsePorts(settings.Web.HttpPort);
+        if (httpPorts.Length == 1 && httpPorts[0] == DefaultConfiguration.DefaultHttpPort &&
+            _tcpService.PortIsTaken(httpPorts[0]))
+        {
+            httpPortsResult.Add(_tcpService.GetNextFreeTcpPort());
+        }
+        else
+        {
+            httpPortsResult.AddRange(httpPorts);
+        }
+
+        if (settings.Web.UseHttps && !string.IsNullOrWhiteSpace(settings.Web.PfxPath) &&
+            !string.IsNullOrWhiteSpace(settings.Web.PfxPassword))
+        {
+            var httpsPorts = ParsePorts(settings.Web.HttpsPort);
+            if (httpsPorts.Length == 1 && httpsPorts[0] == DefaultConfiguration.DefaultHttpsPort &&
+                _tcpService.PortIsTaken(httpsPorts[0]))
+            {
+                httpsPortsResult.Add(_tcpService.GetNextFreeTcpPort());
+            }
+            else
+            {
+                httpsPortsResult.AddRange(httpsPorts);
+            }
+        }
+
+        return (httpPortsResult, httpsPortsResult);
+    }
+
+    private static int[] ParsePorts(string input)
+    {
+        var result = new List<int>();
+        var httpPorts = input.Split(',').Select(p => p.Trim());
+        foreach (var port in httpPorts)
+        {
+            if (!int.TryParse(port, out var parsedPort) || parsedPort is < 1 or > 65535)
+            {
+                throw new ArgumentException($"Port '{port}' is invalid.");
+            }
+
+            result.Add(parsedPort);
+        }
+
+        return result.ToArray();
+    }
+}

--- a/src/HttPlaceholder/Utilities/Implementations/ProgramUtility.cs
+++ b/src/HttPlaceholder/Utilities/Implementations/ProgramUtility.cs
@@ -25,7 +25,7 @@ public class ProgramUtility : IProgramUtility
     /// <summary>
     ///     Constructs a <see cref="ProgramUtility"/> instance.
     /// </summary>
-    private ProgramUtility(ITcpService tcpService)
+    internal ProgramUtility(ITcpService tcpService)
     {
         _tcpService = tcpService;
     }
@@ -36,7 +36,6 @@ public class ProgramUtility : IProgramUtility
         var httpPortsResult = new List<int>();
         var httpsPortsResult = new List<int>();
 
-        // TODO combine these 2 blocks?
         var httpPorts = ParsePorts(settings.Web.HttpPort);
         if (httpPorts.Length == 1 && httpPorts[0] == DefaultConfiguration.DefaultHttpPort &&
             _tcpService.PortIsTaken(httpPorts[0]))

--- a/src/HttPlaceholder/Utilities/Implementations/ProgramUtility.cs
+++ b/src/HttPlaceholder/Utilities/Implementations/ProgramUtility.cs
@@ -48,6 +48,9 @@ public class ProgramUtility : IProgramUtility
     {
         var result = new List<int>();
         var ports = ParsePorts(portInput);
+
+        // If no specific port is configured, the default port will be used.
+        // If that port happens to be taken, look for the next free TCP port.
         if (ports.Length == 1 && ports[0] == defaultPort &&
             _tcpService.PortIsTaken(ports[0]))
         {

--- a/src/HttPlaceholder/Utilities/ProgramUtilities.cs
+++ b/src/HttPlaceholder/Utilities/ProgramUtilities.cs
@@ -7,9 +7,9 @@ using System.Text;
 using HttPlaceholder.Application.Configuration;
 using HttPlaceholder.Application.Configuration.Provider;
 using HttPlaceholder.Common.Utilities;
-using HttPlaceholder.Domain;
 using HttPlaceholder.Infrastructure.Configuration;
 using HttPlaceholder.Resources;
+using HttPlaceholder.Utilities.Implementations;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.Configuration;
@@ -32,7 +32,7 @@ public static class ProgramUtilities
     ///     Configure the logging.
     /// </summary>
     /// <param name="args">The command line arguments.</param>
-    public static void ConfigureLogging(IEnumerable<string> args)
+    public static void ConfigureLogging(string[] args)
     {
         var verbose = IsVerbose(args);
         var loggingConfig = new LoggerConfiguration();
@@ -51,14 +51,13 @@ public static class ProgramUtilities
     ///     Handle several commands.
     /// </summary>
     /// <param name="args">The command line arguments.</param>
-    public static void HandleCommands(IEnumerable<string> args)
+    public static void HandleCommands(string[] args)
     {
         var version = AssemblyHelper.GetAssemblyVersion();
-        var argsArray = args as string[] ?? args.ToArray();
-        HandleArgument(() => Console.WriteLine(version), argsArray, _versionArgs);
+        HandleArgument(() => Console.WriteLine(version), args, _versionArgs);
 
         Console.WriteLine(ManPage.VersionHeader, version, DateTime.Now.Year);
-        HandleArgument(() => Console.WriteLine(GetManPage()), argsArray, _helpArgs);
+        HandleArgument(() => Console.WriteLine(GetManPage()), args, _helpArgs);
     }
 
     /// <summary>
@@ -80,12 +79,10 @@ public static class ProgramUtilities
         return HostBuilderUtilities.CreateHostBuilder()
             .UseSerilog()
             .ConfigureAppConfiguration((_, config) => config.AddCustomInMemoryCollection(argsDictionary))
-            .ConfigureWebHostDefaults(webBuilder =>
-            {
-                webBuilder.UseStartup<Startup>()
-                    .UseKestrel(options => ConfigureKestrel(options, settings))
-                    .UseIIS();
-            })
+            .ConfigureWebHostDefaults(webBuilder => webBuilder
+                .UseStartup<Startup>()
+                .UseKestrel(options => ConfigureKestrel(options, settings))
+                .UseIIS())
             .Build();
     }
 
@@ -105,8 +102,7 @@ public static class ProgramUtilities
     private static void HandleArgument(
         Action action,
         IEnumerable<string> args,
-        IEnumerable<string> argKeys,
-        bool exit = true)
+        IEnumerable<string> argKeys)
     {
         if (!args.Any(argKeys.Contains))
         {
@@ -114,10 +110,7 @@ public static class ProgramUtilities
         }
 
         action();
-        if (exit)
-        {
-            Environment.Exit(0);
-        }
+        Environment.Exit(0);
     }
 
     private static SettingsModel DeserializeSettings(IDictionary<string, string> args)
@@ -129,8 +122,9 @@ public static class ProgramUtilities
 
     private static void ConfigureKestrel(KestrelServerOptions options, SettingsModel settings)
     {
+        var utility = new ProgramUtility();
         options.AddServerHeader = false;
-        var (httpPorts, httpsPorts) = GetPorts(settings);
+        var (httpPorts, httpsPorts) = utility.GetPorts(settings);
         foreach (var port in httpPorts)
         {
             options.Listen(IPAddress.Any, port);
@@ -171,57 +165,6 @@ public static class ProgramUtilities
         builder.AppendLine(ManPage.CmdExample);
 
         return builder.ToString();
-    }
-
-    private static int[] ParsePorts(string input)
-    {
-        var result = new List<int>();
-        var httpPorts = input.Split(',').Select(p => p.Trim());
-        foreach (var port in httpPorts)
-        {
-            if (!int.TryParse(port, out var parsedPort) || parsedPort is < 1 or > 65535)
-            {
-                throw new ArgumentException($"Port '{port}' is invalid.");
-            }
-
-            result.Add(parsedPort);
-        }
-
-        return result.ToArray();
-    }
-
-    private static (IEnumerable<int> httpPorts, IEnumerable<int> httpsPorts) GetPorts(SettingsModel settings)
-    {
-        var httpPortsResult = new List<int>();
-        var httpsPortsResult = new List<int>();
-
-        var httpPorts = ParsePorts(settings.Web.HttpPort);
-        if (httpPorts.Length == 1 && httpPorts[0] == DefaultConfiguration.DefaultHttpPort &&
-            TcpUtilities.PortIsTaken(httpPorts[0]))
-        {
-            httpPortsResult.Add(TcpUtilities.GetNextFreeTcpPort());
-        }
-        else
-        {
-            httpPortsResult.AddRange(httpPorts);
-        }
-
-        if (settings.Web.UseHttps && !string.IsNullOrWhiteSpace(settings.Web.PfxPath) &&
-            !string.IsNullOrWhiteSpace(settings.Web.PfxPassword))
-        {
-            var httpsPorts = ParsePorts(settings.Web.HttpsPort);
-            if (httpsPorts.Length == 1 && httpsPorts[0] == DefaultConfiguration.DefaultHttpsPort &&
-                TcpUtilities.PortIsTaken(httpsPorts[0]))
-            {
-                httpsPortsResult.Add(TcpUtilities.GetNextFreeTcpPort());
-            }
-            else
-            {
-                httpsPortsResult.AddRange(httpsPorts);
-            }
-        }
-
-        return (httpPortsResult, httpsPortsResult);
     }
 
     private static bool IsVerbose(IEnumerable<string> args)

--- a/src/HttPlaceholder/Utilities/ProgramUtilities.cs
+++ b/src/HttPlaceholder/Utilities/ProgramUtilities.cs
@@ -77,7 +77,7 @@ public static class ProgramUtilities
             Console.WriteLine(GetVerbosePage(argsDictionary, args));
         }
 
-        return Host.CreateDefaultBuilder(args)
+        return HostBuilderUtilities.CreateHostBuilder()
             .UseSerilog()
             .ConfigureAppConfiguration((_, config) => config.AddCustomInMemoryCollection(argsDictionary))
             .ConfigureWebHostDefaults(webBuilder =>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

When starting HttPlaceholder in a specific directory with a lot of (sub) folders, HttPlaceholder will scan all these folders and will place a lot of (Inotify) file watches to watch these files. This is very inefficient and completely unnecessary.

![image](https://user-images.githubusercontent.com/6454138/200120098-c80831aa-102c-4f0c-b090-6eed8c5fc727.png)
_Checked with inotify-info when starting HttPlaceholder in my home directory on Ubuntu_

## What is the new behavior?

I found out this behavior is because we use the default web host builder for .NET MVC, which scans the appsettings.{env}.json and appsettings.json files by default. I don't know why so many watches are created, but by removing the scanning of appsettings.*.json files, it seems the problem went away. This is OK, because HttPlaceholder does not use the appsettings files at all.

![image](https://user-images.githubusercontent.com/6454138/200120299-95678de3-ca9c-4a9b-85c1-f1effcf427dc.png)
_After_

StackOverflow post: https://stackoverflow.com/questions/43469400/asp-net-core-the-configured-user-limit-128-on-the-number-of-inotify-instance

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
