### PR TITLE
Upgrade to .NET 7

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 variables:
   DEBIAN_IMAGE: debian:stable-slim
   PWSH_IMAGE: mcr.microsoft.com/powershell:latest
-  DOTNET_IMAGE: mcr.microsoft.com/dotnet/sdk:6.0
+  DOTNET_IMAGE: mcr.microsoft.com/dotnet/sdk:7.0
   NODE_IMAGE: node:lts-stretch-slim
   DOCKER_IMAGE: docker:latest
   PYTHON_IMAGE: python:slim-bullseye

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+[vnext]
+- Upgraded to .NET 7 (https://github.com/dukeofharen/httplaceholder/pull/293).
+
+# BREAKING CHANGES
+- If you use any of the pre-built binaries of HttPlaceholder, you won't notice anything with upgrading. If you use the .NET tool version of HttPlaceholder, you need to have [.NET 7](https://dotnet.microsoft.com/en-us/) installed from now on.
+
 [2022.11.20]
 - Updated loading of stubs from .yml files. An 'id' field should now ALWAYS be set, whereas it was automatically generated beforehand if it was not set (which caused some non stub files to get parsed as stub with weird behavior) (https://github.com/dukeofharen/httplaceholder/pull/284).
 - Added CancellationToken support to .NET client (https://github.com/dukeofharen/httplaceholder/pull/284).

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ COPY . ./
 RUN cd docs/httpl-docs && pip install mkdocs && python sync.py && mkdocs build && cp -r site /app
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:6.0
+FROM mcr.microsoft.com/dotnet/aspnet:7.0
 WORKDIR /app
 COPY --from=build-env /app/out .
 COPY --from=gui-build-env /app/gui/dist ./gui

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build API
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build-env
 WORKDIR /app
 
 COPY . ./

--- a/code-samples/dotnet/HttPlaceholder.Examples.RequestValidation/HttPlaceholder.Examples.RequestValidation.csproj
+++ b/code-samples/dotnet/HttPlaceholder.Examples.RequestValidation/HttPlaceholder.Examples.RequestValidation.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/code-samples/dotnet/HttPlaceholder.Examples.RequestValidation/RequestVerificationTest.cs
+++ b/code-samples/dotnet/HttPlaceholder.Examples.RequestValidation/RequestVerificationTest.cs
@@ -93,7 +93,7 @@ public class RequestVerificationTest
         // Start a HttPlaceholder Docker container.
         // Make sure you can execute Docker on your system without sudo, or else the container can't start.
         return new TestcontainersBuilder<TestcontainersContainer>()
-            .WithImage("dukeofharen/httplaceholder:2022.9.3.59")
+            .WithImage("dukeofharen/httplaceholder:2022.11.20.108")
             .WithName("httplaceholder")
             .WithPortBinding(1337, 5000)
             .WithExposedPort(5000)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     environment:
       fileStorageLocation: /var/stubs
       oldRequestsQueueLength: 300
+      verbose: true
     volumes:
       - stubs:/var/stubs
     ports:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -15,7 +15,7 @@ To set up a development environment, please follow these steps:
 
 ### Setting up development environment for HttPlaceholder
 
-1. Make sure [.NET 6](https://asp.net) is installed.
+1. Make sure [.NET 7](https://asp.net) is installed.
 1. In your terminal, go to the folder `src`.
 1. In the folder, executed the command `dotnet build`. This will download all NuGet packages and makes sure everything builds as intended.
 1. Go to the folder `src/HttPlaceholder`.

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -100,7 +100,7 @@ Follow these steps to install / update HttPlaceholder. If you update HttPlacehol
 
 ## Dotnet global tool (cross platform)
 
-Make sure you have installed the correct .NET SDK (at least .NET 6) for your OS (see https://dotnet.microsoft.com/download). When the .NET SDK is installed, run the following command to install HttPlaceholder:
+Make sure you have installed the correct .NET SDK (at least .NET 7) for your OS (see https://dotnet.microsoft.com/download). When the .NET SDK is installed, run the following command to install HttPlaceholder:
 
 ```shell
 dotnet tool install --global HttPlaceholder

--- a/scripts/build/create-open-api-file.sh
+++ b/scripts/build/create-open-api-file.sh
@@ -14,4 +14,4 @@ fi
 # Run OpenAPI tool
 cd $SWAGGER_GEN_DIR
 dotnet run -c Release
-cp $SWAGGER_GEN_DIR/bin/Release/net6.0/swagger.json $DIST_DIR
+cp $SWAGGER_GEN_DIR/bin/Release/net7.0/swagger.json $DIST_DIR

--- a/src/HttPlaceholder.Application.Tests/HttPlaceholder.Application.Tests.csproj
+++ b/src/HttPlaceholder.Application.Tests/HttPlaceholder.Application.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>

--- a/src/HttPlaceholder.Application.Tests/HttPlaceholder.Application.Tests.csproj
+++ b/src/HttPlaceholder.Application.Tests/HttPlaceholder.Application.Tests.csproj
@@ -12,7 +12,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
         <PackageReference Include="Moq.AutoMock" Version="3.4.0" />
         <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
         <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />

--- a/src/HttPlaceholder.Application/HttPlaceholder.Application.csproj
+++ b/src/HttPlaceholder.Application/HttPlaceholder.Application.csproj
@@ -14,11 +14,11 @@
         <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="5.0.17" />
         <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
-        <PackageReference Include="Microsoft.Extensions.Primitives" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Primitives" Version="7.0.0" />
         <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.4.1" />
         <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
         <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta15" />

--- a/src/HttPlaceholder.Client.Examples/HttPlaceholder.Client.Examples.csproj
+++ b/src/HttPlaceholder.Client.Examples/HttPlaceholder.Client.Examples.csproj
@@ -2,12 +2,12 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/HttPlaceholder.Client.Tests/HttPlaceholder.Client.Tests.csproj
+++ b/src/HttPlaceholder.Client.Tests/HttPlaceholder.Client.Tests.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
         <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
         <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
         <PackageReference Include="coverlet.collector" Version="3.2.0">

--- a/src/HttPlaceholder.Client.Tests/HttPlaceholder.Client.Tests.csproj
+++ b/src/HttPlaceholder.Client.Tests/HttPlaceholder.Client.Tests.csproj
@@ -1,17 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
         <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
         <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-        <PackageReference Include="coverlet.collector" Version="3.1.2">
+        <PackageReference Include="coverlet.collector" Version="3.2.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/HttPlaceholder.Client/HttPlaceholder.Client.csproj
+++ b/src/HttPlaceholder.Client/HttPlaceholder.Client.csproj
@@ -22,11 +22,11 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     </ItemGroup>
 

--- a/src/HttPlaceholder.Common.Tests/HttPlaceholder.Common.Tests.csproj
+++ b/src/HttPlaceholder.Common.Tests/HttPlaceholder.Common.Tests.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
         <PackageReference Include="Moq" Version="4.18.2" />
         <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
         <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />

--- a/src/HttPlaceholder.Common.Tests/HttPlaceholder.Common.Tests.csproj
+++ b/src/HttPlaceholder.Common.Tests/HttPlaceholder.Common.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>

--- a/src/HttPlaceholder.Common/HttPlaceholder.Common.csproj
+++ b/src/HttPlaceholder.Common/HttPlaceholder.Common.csproj
@@ -9,7 +9,7 @@
 
     <ItemGroup>
         <PackageReference Include="AutoMapper" Version="12.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="Scrutor" Version="4.2.0" />
         <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />

--- a/src/HttPlaceholder.Domain.Tests/HttPlaceholder.Domain.Tests.csproj
+++ b/src/HttPlaceholder.Domain.Tests/HttPlaceholder.Domain.Tests.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
         <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
         <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     </ItemGroup>

--- a/src/HttPlaceholder.Domain.Tests/HttPlaceholder.Domain.Tests.csproj
+++ b/src/HttPlaceholder.Domain.Tests/HttPlaceholder.Domain.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>

--- a/src/HttPlaceholder.Infrastructure.Tests/HttPlaceholder.Infrastructure.Tests.csproj
+++ b/src/HttPlaceholder.Infrastructure.Tests/HttPlaceholder.Infrastructure.Tests.csproj
@@ -16,7 +16,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
         <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
         <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     </ItemGroup>

--- a/src/HttPlaceholder.Infrastructure.Tests/HttPlaceholder.Infrastructure.Tests.csproj
+++ b/src/HttPlaceholder.Infrastructure.Tests/HttPlaceholder.Infrastructure.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>

--- a/src/HttPlaceholder.Infrastructure/HttPlaceholder.Infrastructure.csproj
+++ b/src/HttPlaceholder.Infrastructure/HttPlaceholder.Infrastructure.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
         <PackageReference Include="Scrutor" Version="4.2.0" />
     </ItemGroup>
 

--- a/src/HttPlaceholder.Persistence.Tests/HttPlaceholder.Persistence.Tests.csproj
+++ b/src/HttPlaceholder.Persistence.Tests/HttPlaceholder.Persistence.Tests.csproj
@@ -12,7 +12,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
         <PackageReference Include="Moq" Version="4.18.2" />
         <PackageReference Include="Moq.AutoMock" Version="3.4.0" />
         <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />

--- a/src/HttPlaceholder.Persistence.Tests/HttPlaceholder.Persistence.Tests.csproj
+++ b/src/HttPlaceholder.Persistence.Tests/HttPlaceholder.Persistence.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>

--- a/src/HttPlaceholder.Persistence/HttPlaceholder.Persistence.csproj
+++ b/src/HttPlaceholder.Persistence/HttPlaceholder.Persistence.csproj
@@ -9,12 +9,12 @@
 
     <ItemGroup>
         <PackageReference Include="Dapper" Version="2.0.123" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
-        <PackageReference Include="MySqlConnector" Version="2.1.13" />
-        <PackageReference Include="System.Data.SqlClient" Version="4.8.4" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.0" />
+        <PackageReference Include="MySqlConnector" Version="2.2.0" />
+        <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
         <PackageReference Include="System.Data.SQLite" Version="1.0.116" />
     </ItemGroup>
     <ItemGroup>

--- a/src/HttPlaceholder.Resources.Tests/HttPlaceholder.Resources.Tests.csproj
+++ b/src/HttPlaceholder.Resources.Tests/HttPlaceholder.Resources.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/src/HttPlaceholder.Resources.Tests/HttPlaceholder.Resources.Tests.csproj
+++ b/src/HttPlaceholder.Resources.Tests/HttPlaceholder.Resources.Tests.csproj
@@ -14,7 +14,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
         <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
         <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
         <PackageReference Include="Moq" Version="4.18.2" />

--- a/src/HttPlaceholder.Resources/HttPlaceholder.Resources.csproj
+++ b/src/HttPlaceholder.Resources/HttPlaceholder.Resources.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/HttPlaceholder.SwaggerGenerator/HttPlaceholder.SwaggerGenerator.csproj
+++ b/src/HttPlaceholder.SwaggerGenerator/HttPlaceholder.SwaggerGenerator.csproj
@@ -4,7 +4,7 @@
     <Version>2019.8.24.1234</Version>
     <AssemblyVersion>2019.8.24.1234</AssemblyVersion>
     <FileVersion>2019.8.24.1234</FileVersion>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Configurations>Debug;Release;Tool</Configurations>
   </PropertyGroup>
@@ -13,7 +13,7 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\HttPlaceholder\HttPlaceholder.csproj" />

--- a/src/HttPlaceholder.TestUtilities/HttPlaceholder.TestUtilities.csproj
+++ b/src/HttPlaceholder.TestUtilities/HttPlaceholder.TestUtilities.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <Version>2019.8.24.1234</Version>
         <AssemblyVersion>2019.8.24.1234</AssemblyVersion>
         <FileVersion>2019.8.24.1234</FileVersion>

--- a/src/HttPlaceholder.Tests/HttPlaceholder.Tests.csproj
+++ b/src/HttPlaceholder.Tests/HttPlaceholder.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <Version>2019.8.24.1234</Version>
         <AssemblyVersion>2019.8.24.1234</AssemblyVersion>
@@ -21,8 +21,8 @@
         <WarningsAsErrors />
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.10" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
         <PackageReference Include="Moq" Version="4.18.2" />
         <PackageReference Include="Moq.AutoMock" Version="3.4.0" />

--- a/src/HttPlaceholder.Tests/HttPlaceholder.Tests.csproj
+++ b/src/HttPlaceholder.Tests/HttPlaceholder.Tests.csproj
@@ -23,7 +23,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
         <PackageReference Include="Moq" Version="4.18.2" />
         <PackageReference Include="Moq.AutoMock" Version="3.4.0" />
         <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />

--- a/src/HttPlaceholder/HttPlaceholder.csproj
+++ b/src/HttPlaceholder/HttPlaceholder.csproj
@@ -33,7 +33,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0" />
         <PackageReference Include="ncrontab" Version="3.3.1" />
-        <PackageReference Include="NSwag.AspNetCore" Version="13.17.0" />
+        <PackageReference Include="NSwag.AspNetCore" Version="13.18.0" />
         <PackageReference Include="Serilog" Version="2.12.0" />
         <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
         <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />

--- a/src/HttPlaceholder/HttPlaceholder.csproj
+++ b/src/HttPlaceholder/HttPlaceholder.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <PackageId>HttPlaceholder</PackageId>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <Version>2019.8.24.1234</Version>
@@ -29,10 +29,9 @@
         <None Include="../media/logo.png" Pack="true" Visible="false" PackagePath="" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.10" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="6.0.10" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0" />
         <PackageReference Include="ncrontab" Version="3.3.1" />
         <PackageReference Include="NSwag.AspNetCore" Version="13.17.0" />
         <PackageReference Include="Serilog" Version="2.12.0" />


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the new behavior?

Upgrade to .NET 7.

## Does this introduce a breaking change?

- [X] Yes
- [ ] No

If you use any of the pre-built binaries of HttPlaceholder, you won't notice anything with upgrading. If you use the .NET tool version of HttPlaceholder, you need to have [.NET 7](https://dotnet.microsoft.com/en-us/) installed from now on.