### PR TITLE
Updated display URL parser to also support regular expressions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 - Added "show more" button to request body for when the request body is very long (https://github.com/dukeofharen/httplaceholder/pull/294).
 - Added text file response writer (https://github.com/dukeofharen/httplaceholder/pull/295).
 - Updated request body variable parser to also support regular expressions to insert part of request body in the response body (https://github.com/dukeofharen/httplaceholder/pull/296).
+- An option was added to user the display URL variable parser with a regular expression, to parse only a part of the URL as part of your response (https://github.com/dukeofharen/httplaceholder/pull/297).
 
 # BREAKING CHANGES
 - If you use any of the pre-built binaries of HttPlaceholder, you won't notice anything with upgrading. If you use the .NET tool version of HttPlaceholder, you need to have [.NET 7](https://dotnet.microsoft.com/en-us/) installed from now on.

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -1772,7 +1772,7 @@ key3=value3
 
 ### Display URL
 
-The display URL body parser makes it possible to write the complete URL to the response.
+The display URL body parser makes it possible to write the complete URL to the response. It is also possible to provide a regular expression to only parse a part of the display URL in the response body of the stub. When providing a regular expression, you might want to surround the regex with single quotes (see example below) because else the regex might not be parsed correctly.
 
 ```yml
 - id: dynamic-display-url-example
@@ -1794,6 +1794,25 @@ Let's say you do the following GET request: `http://localhost:5000/dynamic-displ
 ```
 URL: http://localhost:5000/dynamic-display-url.txt?var1=value&var2=value2
 ```
+
+```yml
+- id: dynamic-display-url-regex-example
+  conditions:
+    method: GET
+    url:
+      path:
+        regex: /dynamic-display-url-regex/users/(.*)/orders
+  response:
+    enableDynamicMode: true
+    text: "User ID: ((display_url:'\/users\/([0-9]{3})\/orders'))"
+    headers:
+      X-Header: "((display_url:'\/users\/([0-9]{3})\/orders'))"
+  priority: 0
+```
+
+Let's say you make the request `http://localhost:5000/dynamic-display-url-regex/users/123/orders`.
+
+`((display_url:'\/users\/([0-9]{3})\/orders'))` will be replaced with `123`.
 
 ### Root URL
 

--- a/docs/samples/14.6-dynamic-mode-display-url.yml
+++ b/docs/samples/14.6-dynamic-mode-display-url.yml
@@ -12,3 +12,17 @@
     headers:
       X-Header: ((display_url))
   priority: 0
+
+# The display URL of the current request is parsed with a regular expression and the result of the regex is written to the response.
+- id: dynamic-display-url-regex-example
+  conditions:
+    method: GET
+    url:
+      path:
+        regex: /dynamic-display-url-regex/users/(.*)/orders
+  response:
+    enableDynamicMode: true
+    text: "User ID: ((display_url:'\/users\/([0-9]{3})\/orders'))"
+    headers:
+      X-Header: "((display_url:'\/users\/([0-9]{3})\/orders'))"
+  priority: 0

--- a/docs/samples/requests.json
+++ b/docs/samples/requests.json
@@ -857,6 +857,25 @@
 								}
 							},
 							"response": []
+						},
+						{
+							"name": "Regex",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{rootUrl}}dynamic-display-url-regex/users/451/orders",
+									"host": [
+										"{{rootUrl}}dynamic-display-url-regex"
+									],
+									"path": [
+										"users",
+										"451",
+										"orders"
+									]
+								}
+							},
+							"response": []
 						}
 					]
 				},

--- a/src/HttPlaceholder.Application.Tests/StubExecution/ResponseVariableParsingHandlers/DisplayUrlResponseVariableParsingHandlerFacts.cs
+++ b/src/HttPlaceholder.Application.Tests/StubExecution/ResponseVariableParsingHandlers/DisplayUrlResponseVariableParsingHandlerFacts.cs
@@ -35,4 +35,52 @@ public class DisplayUrlResponseVariableParsingHandlerFacts
         // assert
         Assert.AreEqual(expectedResult, result);
     }
+
+    [TestMethod]
+    public async Task RequestBodyVariableHandler_Parse_Regex_HappyFlow()
+    {
+        // arrange
+        const string input = @"User ID: ((display_url:'\/users\/([0-9]{3})\/orders'))";
+        const string url = "http://localhost:5000/users/123/orders?key=value123";
+
+        const string expectedResult = "User ID: 123";
+
+        var httpContextServiceMock = _mocker.GetMock<IHttpContextService>();
+        var handler = _mocker.CreateInstance<DisplayUrlResponseVariableParsingHandler>();
+
+        httpContextServiceMock
+            .Setup(m => m.DisplayUrl)
+            .Returns(url);
+
+        // act
+        var matches = ResponseVariableParser.VarRegex.Matches(input);
+        var result = await handler.ParseAsync(input, matches, new StubModel(), CancellationToken.None);
+
+        // assert
+        Assert.AreEqual(expectedResult, result);
+    }
+
+    [TestMethod]
+    public async Task RequestBodyVariableHandler_Parse_Regex_NoResultFound_HappyFlow()
+    {
+        // arrange
+        const string input = @"User ID: ((display_url:'\/users\/([A-Z]{3})\/orders'))";
+        const string url = "http://localhost:5000/users/123/orders?key=value123";
+
+        const string expectedResult = "User ID: ";
+
+        var httpContextServiceMock = _mocker.GetMock<IHttpContextService>();
+        var handler = _mocker.CreateInstance<DisplayUrlResponseVariableParsingHandler>();
+
+        httpContextServiceMock
+            .Setup(m => m.DisplayUrl)
+            .Returns(url);
+
+        // act
+        var matches = ResponseVariableParser.VarRegex.Matches(input);
+        var result = await handler.ParseAsync(input, matches, new StubModel(), CancellationToken.None);
+
+        // assert
+        Assert.AreEqual(expectedResult, result);
+    }
 }

--- a/src/HttPlaceholder.Application.Tests/StubExecution/ResponseVariableParsingHandlers/RequestBodyResponseVariableParsingHandlerFacts.cs
+++ b/src/HttPlaceholder.Application.Tests/StubExecution/ResponseVariableParsingHandlers/RequestBodyResponseVariableParsingHandlerFacts.cs
@@ -85,4 +85,30 @@ key3=value3";
         // assert
         Assert.AreEqual(expectedResult, result);
     }
+
+    [TestMethod]
+    public async Task RequestBodyVariableHandler_Parse_RegexNoResultFound_HappyFlow()
+    {
+        // arrange
+        const string input = "Posted content: ((request_body:'key4=([a-z0-9]*)'))";
+        const string body = @"key1=value1
+key2=value2
+key3=value3";
+
+        const string expectedResult = "Posted content: ";
+
+        var httpContextServiceMock = _mocker.GetMock<IHttpContextService>();
+        var handler = _mocker.CreateInstance<RequestBodyResponseVariableParsingHandler>();
+
+        httpContextServiceMock
+            .Setup(m => m.GetBodyAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(body);
+
+        // act
+        var matches = ResponseVariableParser.VarRegex.Matches(input);
+        var result = await handler.ParseAsync(input, matches, new StubModel(), CancellationToken.None);
+
+        // assert
+        Assert.AreEqual(expectedResult, result);
+    }
 }

--- a/src/HttPlaceholder.Application/StubExecution/ResponseVariableParsingHandlers/DisplayUrlResponseVariableParsingHandler.cs
+++ b/src/HttPlaceholder.Application/StubExecution/ResponseVariableParsingHandlers/DisplayUrlResponseVariableParsingHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -6,6 +7,7 @@ using HttPlaceholder.Application.Infrastructure.DependencyInjection;
 using HttPlaceholder.Application.Interfaces.Http;
 using HttPlaceholder.Common;
 using HttPlaceholder.Domain;
+using Microsoft.Extensions.Logging;
 
 namespace HttPlaceholder.Application.StubExecution.ResponseVariableParsingHandlers;
 
@@ -15,11 +17,14 @@ namespace HttPlaceholder.Application.StubExecution.ResponseVariableParsingHandle
 internal class DisplayUrlResponseVariableParsingHandler : BaseVariableParsingHandler, ISingletonService
 {
     private readonly IHttpContextService _httpContextService;
+    private readonly ILogger<DisplayUrlResponseVariableParsingHandler> _logger;
 
-    public DisplayUrlResponseVariableParsingHandler(IHttpContextService httpContextService, IFileService fileService) :
+    public DisplayUrlResponseVariableParsingHandler(IHttpContextService httpContextService, IFileService fileService,
+        ILogger<DisplayUrlResponseVariableParsingHandler> logger) :
         base(fileService)
     {
         _httpContextService = httpContextService;
+        _logger = logger;
     }
 
     /// <inheritdoc />
@@ -29,12 +34,50 @@ internal class DisplayUrlResponseVariableParsingHandler : BaseVariableParsingHan
     public override string FullName => "Display URL";
 
     /// <inheritdoc />
-    public override string[] Examples => new[] {$"(({Name}))"};
+    public override string[] Examples => new[] {$"(({Name}))", $@"(({Name}:'\/users\/([0-9]{3})\/orders'))"};
 
     /// <inheritdoc />
     protected override Task<string> InsertVariablesAsync(string input, Match[] matches, StubModel stub,
         CancellationToken cancellationToken) =>
         Task.FromResult(matches
             .Where(match => match.Groups.Count >= 2)
-            .Aggregate(input, (current, match) => current.Replace(match.Value, _httpContextService.DisplayUrl)));
+            .Aggregate(input, (current, match) => HandleDisplayUrl(match, current, _httpContextService.DisplayUrl)));
+
+    private string HandleDisplayUrl(Match match, string current, string url)
+    {
+        var result = string.Empty;
+        if (match.Groups.Count != 3)
+        {
+            _logger.LogWarning(
+                $"Number of regex matches for variable parser {GetType().Name} was {match.Groups.Count}, which should be 3.");
+        }
+        else if (string.IsNullOrWhiteSpace(match.Groups[2].Value))
+        {
+            result = url;
+        }
+        else
+        {
+            var regexValue = match.Groups[2].Value;
+            try
+            {
+                var regex = new Regex(regexValue, RegexOptions.Multiline,
+                    TimeSpan.FromSeconds(Constants.RegexTimeoutSeconds));
+                var matches = regex.Matches(url).ToArray();
+                if (matches.Length >= 1 && matches[0].Groups.Count > 1)
+                {
+                    result = matches[0].Groups[1].Value;
+                }
+                else
+                {
+                    _logger.LogInformation($"No result found in display URL for regular expression '{regexValue}'.");
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, $"Error occurred while executing regex '{regexValue}' on display URL.'");
+            }
+        }
+
+        return current.Replace(match.Value, result);
+    }
 }

--- a/src/HttPlaceholder.Resources/Files/VarParser/display_url-description.md
+++ b/src/HttPlaceholder.Resources/Files/VarParser/display_url-description.md
@@ -1,1 +1,1 @@
-The display URL body parser makes it possible to write the complete URL to the response.
+The display URL body parser makes it possible to write the complete URL to the response. You can also use a regular expression to insert a part of the display URL in the response body.

--- a/src/HttPlaceholder.Tests/Integration/Stubs/StubDynamicModeIntegrationTests.cs
+++ b/src/HttPlaceholder.Tests/Integration/Stubs/StubDynamicModeIntegrationTests.cs
@@ -160,6 +160,30 @@ key3=value3";
     }
 
     [TestMethod]
+    public async Task StubIntegration_RegularGet_Dynamic_DisplayUrl_Regex()
+    {
+        // Arrange
+        var url = $"{TestServer.BaseAddress}dynamic-display-url-regex/users/123/orders?key=val";
+        const string expectedResult = "User ID: 123";
+
+        ClientDataResolverMock
+            .Setup(m => m.GetHost())
+            .Returns("localhost");
+
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+
+        // Act / Assert
+        using var response = await Client.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+        var content = await response.Content.ReadAsStringAsync();
+        Assert.AreEqual(expectedResult, content);
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        Assert.AreEqual(MimeTypes.TextMime, response.Content.Headers.ContentType.ToString());
+
+        Assert.AreEqual("123", response.Headers.Single(h => h.Key == "X-Header").Value.Single());
+    }
+
+    [TestMethod]
     public async Task StubIntegration_RegularGet_Dynamic_RootUrl()
     {
         // Arrange

--- a/src/HttPlaceholder.Tests/Resources/integration.yml
+++ b/src/HttPlaceholder.Tests/Resources/integration.yml
@@ -445,6 +445,19 @@
       X-Header: ((display_url))
   priority: 0
 
+- id: dynamic-display-url-regex-example
+  conditions:
+    method: GET
+    url:
+      path:
+        equals: /dynamic-display-url-regex/users/123/orders
+  response:
+    enableDynamicMode: true
+    text: "User ID: ((display_url:'\/users\/([0-9]{3})\/orders'))"
+    headers:
+      X-Header: "((display_url:'\/users\/([0-9]{3})\/orders'))"
+  priority: 0
+
 - id: dynamic-root-url-example
   conditions:
     method: GET

--- a/test/HttPlaceholderIntegration.postman_collection.json
+++ b/test/HttPlaceholderIntegration.postman_collection.json
@@ -4511,6 +4511,33 @@
 									"response": []
 								},
 								{
+									"name": "[Create stub] Display URL with regex",
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"type": "text",
+												"value": "text/yaml"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "id: dynamic-display-url-regex-example\nconditions:\n  method: GET\n  url:\n    path:\n      equals: /dynamic-display-url-regex/users/123/orders\nresponse:\n  enableDynamicMode: true\n  text: \"User ID: ((display_url:'\\/users\\/([0-9]{3})\\/orders'))\"\n  headers:\n    X-Header: \"((display_url:'\\/users\\/([0-9]{3})\\/orders'))\"\npriority: 0"
+										},
+										"url": {
+											"raw": "{{rootUrl}}ph-api/stubs",
+											"host": [
+												"{{rootUrl}}ph-api"
+											],
+											"path": [
+												"stubs"
+											]
+										}
+									},
+									"response": []
+								},
+								{
 									"name": "[Create stub] Root URL",
 									"request": {
 										"method": "POST",
@@ -5130,6 +5157,59 @@
 												{
 													"key": "q2",
 													"value": "var2"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Test display URL with regex",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Body is correct\", function () {",
+													"    pm.response.to.have.body(\"User ID: 123\");",
+													"});",
+													"",
+													"pm.test(\"Header is correct\", function () {",
+													"    pm.expect(pm.response.headers.get('X-Header')).is.eq(\"123\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "X-Header-1",
+												"type": "text",
+												"value": "val1"
+											},
+											{
+												"key": "X-Header-2",
+												"type": "text",
+												"value": "val2"
+											}
+										],
+										"url": {
+											"raw": "{{rootUrl}}dynamic-display-url-regex/users/123/orders?key=val",
+											"host": [
+												"{{rootUrl}}dynamic-display-url-regex"
+											],
+											"path": [
+												"users",
+												"123",
+												"orders"
+											],
+											"query": [
+												{
+													"key": "key",
+													"value": "val"
 												}
 											]
 										}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the new behavior?

An option was added to user the display URL variable parser with a regular expression, to parse only a part of the URL as part of your response.

```yml
# The display URL of the current request is parsed with a regular expression and the result of the regex is written to the response.
- id: dynamic-display-url-regex-example
  conditions:
    method: GET
    url:
      path:
        regex: /dynamic-display-url-regex/users/(.*)/orders
  response:
    enableDynamicMode: true
    text: "User ID: ((display_url:'\/users\/([0-9]{3})\/orders'))"
    headers:
      X-Header: "((display_url:'\/users\/([0-9]{3})\/orders'))"
  priority: 0
```

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->