### PR TITLE
React to "Cmd + S" on Mac

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@
 - Updated request body variable parser to also support regular expressions to insert part of request body in the response body (https://github.com/dukeofharen/httplaceholder/pull/296).
 - An option was added to user the display URL variable parser with a regular expression, to parse only a part of the URL as part of your response (https://github.com/dukeofharen/httplaceholder/pull/297).
 - Updated the HTTP method condition checker so it is now possible to provide multiple HTTP methods if needed (https://github.com/dukeofharen/httplaceholder/issues/298).
+- Pressing "Cmd + S" now saves the stub form, instead of calling the browser save functionality (https://github.com/dukeofharen/httplaceholder/pull/300).
 
 # BREAKING CHANGES
 - If you use any of the pre-built binaries of HttPlaceholder, you won't notice anything with upgrading. If you use the .NET tool version of HttPlaceholder, you need to have [.NET 7](https://dotnet.microsoft.com/en-us/) installed from now on.

--- a/gui/src/utils/event.ts
+++ b/gui/src/utils/event.ts
@@ -1,5 +1,5 @@
 export function shouldSave(e: KeyboardEvent): boolean {
-  return e.ctrlKey && (e.key === "s" || e.key === "Enter");
+  return (e.ctrlKey || e.metaKey) && (e.key === "s" || e.key === "Enter");
 }
 
 export function escapePressed(e: KeyboardEvent): boolean {


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

"Cmd +S" did not work on Mac OS when filling in the stub form in the UI.

Issue Number: N/A

## What is the new behavior?

Pressing "Cmd + S" now saves the stub.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No