### PR TITLE
Feature/requests bug

### DIFF
--- a/gui/src/components/request/Request.vue
+++ b/gui/src/components/request/Request.vue
@@ -2,7 +2,10 @@
   <accordion-item @buttonClicked="showDetails" :opened="accordionOpened">
     <template v-slot:button-text>
       <span class="request-header">
-        <Method :method="overviewRequest.method" />
+        <Method
+          v-if="overviewRequest.method"
+          :method="overviewRequest.method"
+        />
         <span class="ms-sm-1 request-url" :title="overviewRequest.url">{{
           overviewRequest.url
         }}</span>

--- a/src/HttPlaceholder.Persistence.Tests/Implementations/StubSources/BaseWritableStubSourceFacts.cs
+++ b/src/HttPlaceholder.Persistence.Tests/Implementations/StubSources/BaseWritableStubSourceFacts.cs
@@ -1,0 +1,132 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using HttPlaceholder.Persistence.Implementations.StubSources;
+
+namespace HttPlaceholder.Persistence.Tests.Implementations.StubSources;
+
+[TestClass]
+public class BaseWritableStubSourceFacts
+{
+    [TestMethod]
+    public async Task GetRequestResultsOverviewAsync_RequestParametersIsNull()
+    {
+        // Arrange
+        var request = new RequestResultModel
+        {
+            RequestParameters = null,
+            CorrelationId = Guid.NewGuid().ToString(),
+            StubTenant = "tenant1",
+            ExecutingStubId = "stub1",
+            RequestBeginTime = DateTime.Now,
+            RequestEndTime = DateTime.Now,
+            HasResponse = true
+        };
+        var source = new TestStubSource();
+        source.SetRequests(new[]{request});
+
+        // Act
+        var result = (await source.GetRequestResultsOverviewAsync(CancellationToken.None)).ToArray();
+
+        // Assert
+        Assert.AreEqual(1, result.Length);
+
+        var req = result[0];
+        Assert.IsNull(req.Method);
+        Assert.IsNull(req.Url);
+        Assert.AreEqual(request.CorrelationId, req.CorrelationId);
+        Assert.AreEqual(request.StubTenant, req.StubTenant);
+        Assert.AreEqual(request.ExecutingStubId, req.ExecutingStubId);
+        Assert.AreEqual(request.RequestBeginTime, req.RequestBeginTime);
+        Assert.AreEqual(request.RequestEndTime, req.RequestEndTime);
+        Assert.AreEqual(request.HasResponse, req.HasResponse);
+    }
+
+    [TestMethod]
+    public async Task GetRequestResultsOverviewAsync_RequestParametersIsSet()
+    {
+        // Arrange
+        var request = new RequestResultModel
+        {
+            RequestParameters = new RequestParametersModel
+            {
+                Method = "GET",
+                Url = "/url"
+            },
+            CorrelationId = Guid.NewGuid().ToString(),
+            StubTenant = "tenant1",
+            ExecutingStubId = "stub1",
+            RequestBeginTime = DateTime.Now,
+            RequestEndTime = DateTime.Now,
+            HasResponse = true
+        };
+        var source = new TestStubSource();
+        source.SetRequests(new[]{request});
+
+        // Act
+        var result = (await source.GetRequestResultsOverviewAsync(CancellationToken.None)).ToArray();
+
+        // Assert
+        Assert.AreEqual(1, result.Length);
+
+        var req = result[0];
+        Assert.AreEqual(request.RequestParameters.Method, req.Method);
+        Assert.AreEqual(request.RequestParameters.Url, req.Url);
+        Assert.AreEqual(request.CorrelationId, req.CorrelationId);
+        Assert.AreEqual(request.StubTenant, req.StubTenant);
+        Assert.AreEqual(request.ExecutingStubId, req.ExecutingStubId);
+        Assert.AreEqual(request.RequestBeginTime, req.RequestBeginTime);
+        Assert.AreEqual(request.RequestEndTime, req.RequestEndTime);
+        Assert.AreEqual(request.HasResponse, req.HasResponse);
+    }
+
+    public class TestStubSource : BaseWritableStubSource
+    {
+        private IEnumerable<RequestResultModel> _requests;
+
+        public void SetRequests(IEnumerable<RequestResultModel> requests)
+        {
+            _requests = requests;
+        }
+
+        public override Task<IEnumerable<StubModel>> GetStubsAsync(CancellationToken cancellationToken) =>
+            throw new NotImplementedException();
+
+        public override Task<IEnumerable<StubOverviewModel>>
+            GetStubsOverviewAsync(CancellationToken cancellationToken) => throw new NotImplementedException();
+
+        public override Task<StubModel> GetStubAsync(string stubId, CancellationToken cancellationToken) =>
+            throw new NotImplementedException();
+
+        public override Task PrepareStubSourceAsync(CancellationToken cancellationToken) =>
+            throw new NotImplementedException();
+
+        public override Task AddStubAsync(StubModel stub, CancellationToken cancellationToken) =>
+            throw new NotImplementedException();
+
+        public override Task<bool> DeleteStubAsync(string stubId, CancellationToken cancellationToken) =>
+            throw new NotImplementedException();
+
+        public override Task AddRequestResultAsync(RequestResultModel requestResult, ResponseModel responseModel,
+            CancellationToken cancellationToken) =>
+            throw new NotImplementedException();
+
+        public override Task<IEnumerable<RequestResultModel>> GetRequestResultsAsync(
+            CancellationToken cancellationToken) => Task.FromResult(_requests);
+
+        public override Task<RequestResultModel> GetRequestAsync(string correlationId,
+            CancellationToken cancellationToken) => throw new NotImplementedException();
+
+        public override Task<ResponseModel>
+            GetResponseAsync(string correlationId, CancellationToken cancellationToken) =>
+            throw new NotImplementedException();
+
+        public override Task DeleteAllRequestResultsAsync(CancellationToken cancellationToken) =>
+            throw new NotImplementedException();
+
+        public override Task<bool> DeleteRequestAsync(string correlationId, CancellationToken cancellationToken) =>
+            throw new NotImplementedException();
+
+        public override Task CleanOldRequestResultsAsync(CancellationToken cancellationToken) =>
+            throw new NotImplementedException();
+    }
+}

--- a/src/HttPlaceholder.Persistence.Tests/Implementations/StubSources/FileSystemStubSourceFacts.cs
+++ b/src/HttPlaceholder.Persistence.Tests/Implementations/StubSources/FileSystemStubSourceFacts.cs
@@ -438,57 +438,6 @@ public class FileSystemStubSourceFacts
     }
 
     [TestMethod]
-    public async Task GetRequestResultsOverviewAsync_HappyFlow()
-    {
-        // Arrange
-        var requestsFolder = Path.Combine(StorageFolder, FileNames.RequestsFolderName);
-        var files = new[]
-        {
-            Path.Combine(requestsFolder, "request-01.json"), Path.Combine(requestsFolder, "request-02.json")
-        };
-
-        var fileServiceMock = _mocker.GetMock<IFileService>();
-        var source = _mocker.CreateInstance<FileSystemStubSource>();
-
-        fileServiceMock
-            .Setup(m => m.GetFilesAsync(requestsFolder, "*.json", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(files);
-
-        var requestFileContents = new[]
-        {
-            JsonConvert.SerializeObject(new RequestResultModel
-            {
-                CorrelationId = "request-01",
-                RequestParameters = new RequestParametersModel(),
-                HasResponse = true
-            }),
-            JsonConvert.SerializeObject(new RequestResultModel
-            {
-                CorrelationId = "request-02",
-                RequestParameters = new RequestParametersModel(),
-                HasResponse = false
-            })
-        };
-
-        for (var i = 0; i < files.Length; i++)
-        {
-            var file = files[i];
-            var contents = requestFileContents[i];
-            fileServiceMock
-                .Setup(m => m.ReadAllTextAsync(file, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(contents);
-        }
-
-        // Act
-        var result = (await source.GetRequestResultsOverviewAsync(CancellationToken.None)).ToArray();
-
-        // Assert
-        Assert.AreEqual(2, result.Length);
-        Assert.AreEqual("request-01", result[0].CorrelationId);
-        Assert.AreEqual("request-02", result[1].CorrelationId);
-    }
-
-    [TestMethod]
     public async Task CleanOldRequestResultsAsync_HappyFlow()
     {
         // Arrange

--- a/src/HttPlaceholder.Persistence.Tests/Implementations/StubSources/InMemoryStubSourceFacts.cs
+++ b/src/HttPlaceholder.Persistence.Tests/Implementations/StubSources/InMemoryStubSourceFacts.cs
@@ -4,7 +4,7 @@ using Bogus;
 using HttPlaceholder.Application.Configuration;
 using HttPlaceholder.Persistence.Implementations.StubSources;
 
-namespace HttPlaceholder.Persistence.Tests.Implementations;
+namespace HttPlaceholder.Persistence.Tests.Implementations.StubSources;
 
 [TestClass]
 public class InMemoryStubSourceFacts
@@ -65,32 +65,6 @@ public class InMemoryStubSourceFacts
 
         // Assert
         Assert.AreEqual(stub, source.StubModels.Single());
-    }
-
-    [TestMethod]
-    public async Task GetRequestResultsOverviewAsync_HappyFlow()
-    {
-        // Arrange
-        var source = _mocker.CreateInstance<InMemoryStubSource>();
-        var requestModel = CreateRequestResultModel();
-        source.RequestResultModels.Add(requestModel);
-
-        // Act
-        var result = (await source.GetRequestResultsOverviewAsync(CancellationToken.None)).ToArray();
-
-        // Assert
-        Assert.AreEqual(1, result.Length);
-
-        var overviewRequest = result.Single();
-        var reqParams = requestModel.RequestParameters;
-        Assert.AreEqual(reqParams.Method, overviewRequest.Method);
-        Assert.AreEqual(reqParams.Url, overviewRequest.Url);
-        Assert.AreEqual(requestModel.CorrelationId, overviewRequest.CorrelationId);
-        Assert.AreEqual(requestModel.StubTenant, overviewRequest.StubTenant);
-        Assert.AreEqual(requestModel.ExecutingStubId, overviewRequest.ExecutingStubId);
-        Assert.AreEqual(requestModel.RequestBeginTime, overviewRequest.RequestBeginTime);
-        Assert.AreEqual(requestModel.RequestEndTime, overviewRequest.RequestEndTime);
-        Assert.AreEqual(requestModel.HasResponse, overviewRequest.HasResponse);
     }
 
     [TestMethod]

--- a/src/HttPlaceholder.Persistence.Tests/Implementations/StubSources/RelationalDbStubSourceFacts.cs
+++ b/src/HttPlaceholder.Persistence.Tests/Implementations/StubSources/RelationalDbStubSourceFacts.cs
@@ -195,49 +195,6 @@ public class RelationalDbStubSourceFacts
     }
 
     [TestMethod]
-    public async Task GetRequestResultsOverviewAsync_ShouldReturnRequestsSuccessfully()
-    {
-        // Arrange
-        const string query = "GET REQUESTS QUERY";
-        var mockQueryStore = _mocker.GetMock<IQueryStore>();
-        mockQueryStore
-            .Setup(m => m.GetRequestsQuery)
-            .Returns(query);
-
-        var stubSource = _mocker.CreateInstance<RelationalDbStubSource>();
-
-        var request1 = new RequestResultModel
-        {
-            RequestParameters = new RequestParametersModel {Method = "GET", Url = "http://localhost:5000"},
-            CorrelationId = Guid.NewGuid().ToString(),
-            StubTenant = "tenant-name",
-            ExecutingStubId = "stub1",
-            RequestBeginTime = DateTime.Today,
-            RequestEndTime = DateTime.Today.AddSeconds(2),
-            HasResponse = true
-        };
-        var requests = new[] {new DbRequestModel {Json = JsonConvert.SerializeObject(request1)}};
-        _mockDatabaseContext
-            .Setup(m => m.QueryAsync<DbRequestModel>(query, It.IsAny<CancellationToken>(), null))
-            .ReturnsAsync(requests);
-
-        // Act
-        var result = (await stubSource.GetRequestResultsOverviewAsync(CancellationToken.None)).ToArray();
-
-        // Assert
-        Assert.AreEqual(1, result.Length);
-
-        var overviewModel = result.Single();
-        Assert.AreEqual(request1.RequestParameters.Method, overviewModel.Method);
-        Assert.AreEqual(request1.RequestParameters.Url, overviewModel.Url);
-        Assert.AreEqual(request1.CorrelationId, overviewModel.CorrelationId);
-        Assert.AreEqual(request1.StubTenant, overviewModel.StubTenant);
-        Assert.AreEqual(request1.RequestBeginTime, overviewModel.RequestBeginTime);
-        Assert.AreEqual(request1.RequestEndTime, overviewModel.RequestEndTime);
-        Assert.AreEqual(request1.HasResponse, overviewModel.HasResponse);
-    }
-
-    [TestMethod]
     public async Task GetRequestAsync_RequestFound_ShouldReturnRequestSuccessfully()
     {
         // Arrange

--- a/src/HttPlaceholder.Persistence/Implementations/StubSources/BaseWritableStubSource.cs
+++ b/src/HttPlaceholder.Persistence/Implementations/StubSources/BaseWritableStubSource.cs
@@ -58,8 +58,8 @@ public abstract class BaseWritableStubSource : IWritableStubSource
         (await GetRequestResultsAsync(cancellationToken))
         .Select(r => new RequestOverviewModel
         {
-            Method = r.RequestParameters.Method,
-            Url = r.RequestParameters.Url,
+            Method = r.RequestParameters?.Method,
+            Url = r.RequestParameters?.Url,
             CorrelationId = r.CorrelationId,
             StubTenant = r.StubTenant,
             ExecutingStubId = r.ExecutingStubId,

--- a/src/HttPlaceholder.Persistence/Implementations/StubSources/BaseWritableStubSource.cs
+++ b/src/HttPlaceholder.Persistence/Implementations/StubSources/BaseWritableStubSource.cs
@@ -1,0 +1,70 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using HttPlaceholder.Application.Interfaces.Persistence;
+using HttPlaceholder.Domain;
+
+namespace HttPlaceholder.Persistence.Implementations.StubSources;
+
+/// <summary>
+///     An abstract class that is used to implement a stub source types that also writes its data to a data source.
+/// </summary>
+public abstract class BaseWritableStubSource : IWritableStubSource
+{
+    /// <inheritdoc />
+    public abstract Task<IEnumerable<StubModel>> GetStubsAsync(CancellationToken cancellationToken);
+
+    /// <inheritdoc />
+    public abstract Task<IEnumerable<StubOverviewModel>> GetStubsOverviewAsync(CancellationToken cancellationToken);
+
+    /// <inheritdoc />
+    public abstract Task<StubModel> GetStubAsync(string stubId, CancellationToken cancellationToken);
+
+    /// <inheritdoc />
+    public abstract Task PrepareStubSourceAsync(CancellationToken cancellationToken);
+
+    /// <inheritdoc />
+    public abstract Task AddStubAsync(StubModel stub, CancellationToken cancellationToken);
+
+    /// <inheritdoc />
+    public abstract Task<bool> DeleteStubAsync(string stubId, CancellationToken cancellationToken);
+
+    /// <inheritdoc />
+    public abstract Task AddRequestResultAsync(RequestResultModel requestResult, ResponseModel responseModel,
+        CancellationToken cancellationToken);
+
+    /// <inheritdoc />
+    public abstract Task<IEnumerable<RequestResultModel>> GetRequestResultsAsync(CancellationToken cancellationToken);
+
+    /// <inheritdoc />
+    public abstract Task<RequestResultModel> GetRequestAsync(string correlationId, CancellationToken cancellationToken);
+
+    /// <inheritdoc />
+    public abstract Task<ResponseModel> GetResponseAsync(string correlationId, CancellationToken cancellationToken);
+
+    /// <inheritdoc />
+    public abstract Task DeleteAllRequestResultsAsync(CancellationToken cancellationToken);
+
+    /// <inheritdoc />
+    public abstract Task<bool> DeleteRequestAsync(string correlationId, CancellationToken cancellationToken);
+
+    /// <inheritdoc />
+    public abstract Task CleanOldRequestResultsAsync(CancellationToken cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<RequestOverviewModel>> GetRequestResultsOverviewAsync(
+        CancellationToken cancellationToken) =>
+        (await GetRequestResultsAsync(cancellationToken))
+        .Select(r => new RequestOverviewModel
+        {
+            Method = r.RequestParameters.Method,
+            Url = r.RequestParameters.Url,
+            CorrelationId = r.CorrelationId,
+            StubTenant = r.StubTenant,
+            ExecutingStubId = r.ExecutingStubId,
+            RequestBeginTime = r.RequestBeginTime,
+            RequestEndTime = r.RequestEndTime,
+            HasResponse = r.HasResponse
+        });
+}

--- a/src/HttPlaceholder.Persistence/Implementations/StubSources/InMemoryStubSource.cs
+++ b/src/HttPlaceholder.Persistence/Implementations/StubSources/InMemoryStubSource.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using HttPlaceholder.Application.Configuration;
-using HttPlaceholder.Application.Interfaces.Persistence;
 using HttPlaceholder.Domain;
 using Microsoft.Extensions.Options;
 
@@ -12,7 +11,7 @@ namespace HttPlaceholder.Persistence.Implementations.StubSources;
 /// <summary>
 ///     A stub source that is used to store and read data from memory.
 /// </summary>
-internal class InMemoryStubSource : IWritableStubSource
+internal class InMemoryStubSource : BaseWritableStubSource
 {
     private static readonly object _lock = new();
 
@@ -31,7 +30,7 @@ internal class InMemoryStubSource : IWritableStubSource
     }
 
     /// <inheritdoc />
-    public Task AddRequestResultAsync(RequestResultModel requestResult, ResponseModel responseModel,
+    public override Task AddRequestResultAsync(RequestResultModel requestResult, ResponseModel responseModel,
         CancellationToken cancellationToken)
     {
         lock (_lock)
@@ -49,7 +48,7 @@ internal class InMemoryStubSource : IWritableStubSource
     }
 
     /// <inheritdoc />
-    public Task AddStubAsync(StubModel stub, CancellationToken cancellationToken)
+    public override Task AddStubAsync(StubModel stub, CancellationToken cancellationToken)
     {
         lock (_lock)
         {
@@ -59,22 +58,7 @@ internal class InMemoryStubSource : IWritableStubSource
     }
 
     /// <inheritdoc />
-    public async Task<IEnumerable<RequestOverviewModel>> GetRequestResultsOverviewAsync(
-        CancellationToken cancellationToken) =>
-        (await GetRequestResultsAsync(cancellationToken)).Select(r => new RequestOverviewModel
-        {
-            Method = r.RequestParameters?.Method,
-            Url = r.RequestParameters?.Url,
-            CorrelationId = r.CorrelationId,
-            StubTenant = r.StubTenant,
-            ExecutingStubId = r.ExecutingStubId,
-            RequestBeginTime = r.RequestBeginTime,
-            RequestEndTime = r.RequestEndTime,
-            HasResponse = r.HasResponse
-        });
-
-    /// <inheritdoc />
-    public Task<RequestResultModel> GetRequestAsync(string correlationId, CancellationToken cancellationToken)
+    public override Task<RequestResultModel> GetRequestAsync(string correlationId, CancellationToken cancellationToken)
     {
         lock (_lock)
         {
@@ -83,7 +67,7 @@ internal class InMemoryStubSource : IWritableStubSource
     }
 
     /// <inheritdoc />
-    public Task<ResponseModel> GetResponseAsync(string correlationId, CancellationToken cancellationToken)
+    public override Task<ResponseModel> GetResponseAsync(string correlationId, CancellationToken cancellationToken)
     {
         lock (_lock)
         {
@@ -99,7 +83,7 @@ internal class InMemoryStubSource : IWritableStubSource
     }
 
     /// <inheritdoc />
-    public Task DeleteAllRequestResultsAsync(CancellationToken cancellationToken)
+    public override Task DeleteAllRequestResultsAsync(CancellationToken cancellationToken)
     {
         lock (_lock)
         {
@@ -111,7 +95,7 @@ internal class InMemoryStubSource : IWritableStubSource
     }
 
     /// <inheritdoc />
-    public Task<bool> DeleteRequestAsync(string correlationId, CancellationToken cancellationToken)
+    public override Task<bool> DeleteRequestAsync(string correlationId, CancellationToken cancellationToken)
     {
         lock (_lock)
         {
@@ -128,7 +112,7 @@ internal class InMemoryStubSource : IWritableStubSource
     }
 
     /// <inheritdoc />
-    public Task<bool> DeleteStubAsync(string stubId, CancellationToken cancellationToken)
+    public override Task<bool> DeleteStubAsync(string stubId, CancellationToken cancellationToken)
     {
         lock (_lock)
         {
@@ -144,7 +128,7 @@ internal class InMemoryStubSource : IWritableStubSource
     }
 
     /// <inheritdoc />
-    public Task<IEnumerable<RequestResultModel>> GetRequestResultsAsync(CancellationToken cancellationToken)
+    public override Task<IEnumerable<RequestResultModel>> GetRequestResultsAsync(CancellationToken cancellationToken)
     {
         lock (_lock)
         {
@@ -153,7 +137,7 @@ internal class InMemoryStubSource : IWritableStubSource
     }
 
     /// <inheritdoc />
-    public Task<IEnumerable<StubModel>> GetStubsAsync(CancellationToken cancellationToken)
+    public override Task<IEnumerable<StubModel>> GetStubsAsync(CancellationToken cancellationToken)
     {
         lock (_lock)
         {
@@ -163,17 +147,17 @@ internal class InMemoryStubSource : IWritableStubSource
     }
 
     /// <inheritdoc />
-    public async Task<IEnumerable<StubOverviewModel>> GetStubsOverviewAsync(CancellationToken cancellationToken) =>
+    public override async Task<IEnumerable<StubOverviewModel>> GetStubsOverviewAsync(CancellationToken cancellationToken) =>
         (await GetStubsAsync(cancellationToken))
         .Select(s => new StubOverviewModel {Id = s.Id, Tenant = s.Tenant, Enabled = s.Enabled})
         .ToArray();
 
     /// <inheritdoc />
-    public Task<StubModel> GetStubAsync(string stubId, CancellationToken cancellationToken) =>
+    public override Task<StubModel> GetStubAsync(string stubId, CancellationToken cancellationToken) =>
         Task.FromResult(StubModels.FirstOrDefault(s => s.Id == stubId));
 
     /// <inheritdoc />
-    public Task CleanOldRequestResultsAsync(CancellationToken cancellationToken)
+    public override Task CleanOldRequestResultsAsync(CancellationToken cancellationToken)
     {
         lock (_lock)
         {
@@ -192,7 +176,7 @@ internal class InMemoryStubSource : IWritableStubSource
     }
 
     /// <inheritdoc />
-    public Task PrepareStubSourceAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    public override Task PrepareStubSourceAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
     private void RemoveResponse(RequestResultModel request)
     {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Whenever, for some reason, for a request the request parameters were not saved (e.g. the request paramaters are NULL), the "request overview" endpoint just returns a 500.

## What is the new behavior?

A NULL check is performed before returning the results now. The UI can handle the NULL response just well.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No