### PR TITLE
Feature/create stub request with response

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@
 - Fixed requests bug: whenever the request parameters were not saved (may happen in some rare cases when HttPlaceholder is DDOS'ed), the API returned an HTTP 500 (https://github.com/dukeofharen/httplaceholder/pull/308).
 - Added string / regex replacement response writer (https://github.com/dukeofharen/httplaceholder/pull/309).
 - Added SignalR connection for stubs (https://github.com/dukeofharen/httplaceholder/pull/310).
+- When generating a stub based on a request, also take the saved saved response (if there is one) into account (https://github.com/dukeofharen/httplaceholder/pull/311).
 
 [2023.4.25]
 - Upgraded to .NET 7 (https://github.com/dukeofharen/httplaceholder/pull/293).

--- a/gui/src/views/Stubs.vue
+++ b/gui/src/views/Stubs.vue
@@ -259,7 +259,7 @@ export default defineComponent({
       signalrConnection.on("StubDeleted", (stubId: string) => {
         const stub = stubs.value.find((s) => s.stub.id === stubId);
         if (stub) {
-          stubs.value.splice(stubs.value.indexOf(stub, 1));
+          stubs.value.splice(stubs.value.indexOf(stub), 1);
         }
       });
       try {

--- a/src/HttPlaceholder.Application.Tests/StubExecution/Implementations/RequestStubGeneratorFacts.cs
+++ b/src/HttPlaceholder.Application.Tests/StubExecution/Implementations/RequestStubGeneratorFacts.cs
@@ -108,4 +108,59 @@ public class RequestStubGeneratorFacts
         stubContextMock.Verify(m => m.DeleteStubAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
         stubContextMock.Verify(m => m.AddStubAsync(It.IsAny<StubModel>(), It.IsAny<CancellationToken>()), Times.Never);
     }
+
+    [TestMethod]
+    public async Task GenerateStubBasedOnRequestAsync_RequestFound_ResponseFound()
+    {
+        // Arrange
+        var stubContextMock = _mocker.GetMock<IStubContext>();
+        var mapperMock = _mocker.GetMock<IMapper>();
+        var httpRequestToConditionsServiceMock = _mocker.GetMock<IHttpRequestToConditionsService>();
+        var httpResponseToStubResponseServiceMock = _mocker.GetMock<IHttpResponseToStubResponseService>();
+        var generator = _mocker.CreateInstance<RequestStubGenerator>();
+
+        const string expectedStubId = "generated-8358757ce7fac539123f33db05bb11b5";
+
+        var request =
+            new RequestResultModel {CorrelationId = "2", RequestParameters = new RequestParametersModel()};
+
+        stubContextMock
+            .Setup(m => m.GetRequestResultAsync("2", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(request);
+
+        var mappedRequest = new HttpRequestModel();
+        mapperMock
+            .Setup(m => m.Map<HttpRequestModel>(request.RequestParameters))
+            .Returns(mappedRequest);
+
+        var conditions = new StubConditionsModel();
+        httpRequestToConditionsServiceMock
+            .Setup(m => m.ConvertToConditionsAsync(mappedRequest, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(conditions);
+
+        var response = new ResponseModel();
+        stubContextMock
+            .Setup(m => m.GetResponseAsync("2", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+        var mappedResponse = new HttpResponseModel();
+        mapperMock
+            .Setup(m => m.Map<HttpResponseModel>(response))
+            .Returns(mappedResponse);
+        var stubResponse = new StubResponseModel();
+        httpResponseToStubResponseServiceMock
+            .Setup(m => m.ConvertToResponseAsync(mappedResponse, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(stubResponse);
+
+        // Act
+        var result = await generator.GenerateStubBasedOnRequestAsync("2", true, CancellationToken.None);
+
+        // Assert
+        Assert.IsNotNull(result.Metadata);
+        Assert.AreEqual(stubResponse, result.Stub.Response);
+        Assert.AreEqual(expectedStubId, result.Stub.Id);
+        Assert.AreEqual(conditions, result.Stub.Conditions);
+
+        stubContextMock.Verify(m => m.DeleteStubAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        stubContextMock.Verify(m => m.AddStubAsync(It.IsAny<StubModel>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
 }

--- a/src/HttPlaceholder.Application.Tests/StubExecution/Models/HttpResponseModelFacts.cs
+++ b/src/HttPlaceholder.Application.Tests/StubExecution/Models/HttpResponseModelFacts.cs
@@ -1,0 +1,39 @@
+﻿using System.Text;
+using AutoMapper;
+using HttPlaceholder.Application.StubExecution.Models;
+
+namespace HttPlaceholder.Application.Tests.StubExecution.Models;
+
+[TestClass]
+public class HttpResponseModelFacts
+{
+    private readonly IMapper _mapper = AutoMapperHelper.CreateMapper();
+
+    [TestMethod]
+    public void ResponseBodyIsBinary_ShouldConvertToBase64()
+    {
+        // Arrange
+        var response = new ResponseModel {BodyIsBinary = true, Body = new byte[] {1, 2, 3}};
+
+        // Act
+        var result = _mapper.Map<HttpResponseModel>(response);
+
+        // Assert
+        Assert.IsTrue(result.ContentIsBase64);
+        Assert.AreEqual("AQID", result.Content);
+    }
+
+    [TestMethod]
+    public void ResponseBodyIsNotBinary_ShouldConvertToStringAsIs()
+    {
+        // Arrange
+        var response = new ResponseModel {BodyIsBinary = false, Body = "some text"u8.ToArray()};
+
+        // Act
+        var result = _mapper.Map<HttpResponseModel>(response);
+
+        // Assert
+        Assert.IsFalse(result.ContentIsBase64);
+        Assert.AreEqual("some text", result.Content);
+    }
+}

--- a/src/HttPlaceholder.Application/StubExecution/Implementations/RequestStubGenerator.cs
+++ b/src/HttPlaceholder.Application/StubExecution/Implementations/RequestStubGenerator.cs
@@ -45,7 +45,7 @@ internal class RequestStubGenerator : IRequestStubGenerator, ISingletonService
         var request = _mapper.Map<HttpRequestModel>(requestResult.RequestParameters);
         var response = await _stubContext.GetResponseAsync(requestCorrelationId, cancellationToken);
         var httpResponseModel = _mapper.Map<HttpResponseModel>(response);
-        var stubResponse = response != null
+        var stubResponse = httpResponseModel != null
             ? await _httpResponseToStubResponseService.ConvertToResponseAsync(httpResponseModel, cancellationToken)
             : new StubResponseModel {Text = "OK!"};
         var stub = new StubModel

--- a/src/HttPlaceholder.Application/StubExecution/Implementations/RequestStubGenerator.cs
+++ b/src/HttPlaceholder.Application/StubExecution/Implementations/RequestStubGenerator.cs
@@ -17,17 +17,20 @@ internal class RequestStubGenerator : IRequestStubGenerator, ISingletonService
     private readonly ILogger<RequestStubGenerator> _logger;
     private readonly IMapper _mapper;
     private readonly IStubContext _stubContext;
+    private readonly IHttpResponseToStubResponseService _httpResponseToStubResponseService;
 
     public RequestStubGenerator(
         IStubContext stubContext,
         ILogger<RequestStubGenerator> logger,
         IMapper mapper,
-        IHttpRequestToConditionsService httpRequestToConditionsService)
+        IHttpRequestToConditionsService httpRequestToConditionsService,
+        IHttpResponseToStubResponseService httpResponseToStubResponseService)
     {
         _stubContext = stubContext;
         _logger = logger;
         _mapper = mapper;
         _httpRequestToConditionsService = httpRequestToConditionsService;
+        _httpResponseToStubResponseService = httpResponseToStubResponseService;
     }
 
     /// <inheritdoc />
@@ -40,10 +43,15 @@ internal class RequestStubGenerator : IRequestStubGenerator, ISingletonService
         var requestResult = await _stubContext.GetRequestResultAsync(requestCorrelationId, cancellationToken)
             .IfNull(() => throw new NotFoundException(nameof(RequestResultModel), requestCorrelationId));
         var request = _mapper.Map<HttpRequestModel>(requestResult.RequestParameters);
+        var response = await _stubContext.GetResponseAsync(requestCorrelationId, cancellationToken);
+        var httpResponseModel = _mapper.Map<HttpResponseModel>(response);
+        var stubResponse = response != null
+            ? await _httpResponseToStubResponseService.ConvertToResponseAsync(httpResponseModel, cancellationToken)
+            : new StubResponseModel {Text = "OK!"};
         var stub = new StubModel
         {
             Conditions = await _httpRequestToConditionsService.ConvertToConditionsAsync(request, cancellationToken),
-            Response = {Text = "OK!"}
+            Response = stubResponse
         };
 
         // Generate an ID based on the created stub.

--- a/src/HttPlaceholder.Application/StubExecution/Models/HttpResponseModel.cs
+++ b/src/HttPlaceholder.Application/StubExecution/Models/HttpResponseModel.cs
@@ -1,11 +1,18 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using AutoMapper;
+using HttPlaceholder.Application.Interfaces.Mappings;
+using HttPlaceholder.Domain;
 
 namespace HttPlaceholder.Application.StubExecution.Models;
 
 /// <summary>
 ///     A model that contains a representation of an HTTP response.
+///     This model is mainly used in converting one data source (e.g. a HTTP Archive, or HAR) to an intermediate data source
+///     that can be used to generate a response for use in a stub.
 /// </summary>
-public class HttpResponseModel
+public class HttpResponseModel : IHaveCustomMapping
 {
     /// <summary>
     ///     Gets or sets the HTTP status code.
@@ -26,4 +33,23 @@ public class HttpResponseModel
     ///     Gets or sets whether the content is Base64 encoded.
     /// </summary>
     public bool ContentIsBase64 { get; set; }
+
+    /// <inheritdoc />
+    public void CreateMappings(Profile configuration) =>
+        configuration.CreateMap<ResponseModel, HttpResponseModel>()
+            .ForMember(src => src.Content, opt => opt.Ignore())
+            .ForMember(src => src.ContentIsBase64, opt => opt.Ignore())
+            .AfterMap((src, dest, _) =>
+            {
+                if (src.BodyIsBinary)
+                {
+                    dest.ContentIsBase64 = true;
+                    dest.Content = Convert.ToBase64String(src.Body);
+                }
+                else
+                {
+                    dest.ContentIsBase64 = false;
+                    dest.Content = Encoding.UTF8.GetString(src.Body);
+                }
+            });
 }

--- a/test/HttPlaceholderIntegration.postman_collection.json
+++ b/test/HttPlaceholderIntegration.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "7152af4c-ab96-43bf-a8b0-66dd4a00b300",
+		"_postman_id": "950b32ea-a46e-400d-875e-87b87f20b0a7",
 		"name": "HttPlaceholder Integration",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -6553,7 +6553,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.environment.set(\"corrId\", pm.response.headers.get('x-httplaceholder-correlation'));"
+													"pm.globals.set(\"corrId\", pm.response.headers.get('x-httplaceholder-correlation'));"
 												],
 												"type": "text/javascript"
 											}
@@ -6981,7 +6981,7 @@
 															"});",
 															"",
 															"const corrId = pm.response.headers.get('X-HttPlaceholder-Correlation');",
-															"pm.environment.set(\"corrId\", corrId);"
+															"pm.globals.set(\"corrId\", corrId);"
 														],
 														"type": "text/javascript"
 													}
@@ -7121,7 +7121,7 @@
 															"});",
 															"",
 															"const corrId = pm.response.headers.get('X-HttPlaceholder-Correlation');",
-															"pm.environment.set(\"corrId\", corrId);"
+															"pm.globals.set(\"corrId\", corrId);"
 														],
 														"type": "text/javascript"
 													}
@@ -7279,7 +7279,7 @@
 															"});",
 															"",
 															"const corrId = pm.response.headers.get('X-HttPlaceholder-Correlation');",
-															"pm.environment.set(\"corrId\", corrId);"
+															"pm.globals.set(\"corrId\", corrId);"
 														],
 														"type": "text/javascript"
 													}
@@ -7441,7 +7441,7 @@
 															"});",
 															"",
 															"const corrId = pm.response.headers.get('X-HttPlaceholder-Correlation');",
-															"pm.environment.set(\"corrId\", corrId);"
+															"pm.globals.set(\"corrId\", corrId);"
 														],
 														"type": "text/javascript"
 													}
@@ -7562,7 +7562,7 @@
 															"});",
 															"",
 															"const corrId = pm.response.headers.get('X-HttPlaceholder-Correlation');",
-															"pm.environment.set(\"corrId\", corrId);"
+															"pm.globals.set(\"corrId\", corrId);"
 														],
 														"type": "text/javascript"
 													}
@@ -7672,7 +7672,7 @@
 															"});",
 															"",
 															"const corrId = pm.response.headers.get('X-HttPlaceholder-Correlation');",
-															"pm.environment.set(\"corrId\", corrId);"
+															"pm.globals.set(\"corrId\", corrId);"
 														],
 														"type": "text/javascript"
 													}
@@ -7781,7 +7781,7 @@
 															"});",
 															"",
 															"const corrId = pm.response.headers.get('X-HttPlaceholder-Correlation');",
-															"pm.environment.set(\"corrId\", corrId);"
+															"pm.globals.set(\"corrId\", corrId);"
 														],
 														"type": "text/javascript"
 													}
@@ -7903,7 +7903,7 @@
 															"});",
 															"",
 															"const corrId = pm.response.headers.get('X-HttPlaceholder-Correlation');",
-															"pm.environment.set(\"corrId\", corrId);"
+															"pm.globals.set(\"corrId\", corrId);"
 														],
 														"type": "text/javascript"
 													}
@@ -8049,7 +8049,7 @@
 																	"});",
 																	"",
 																	"const corrId = pm.response.headers.get('X-HttPlaceholder-Correlation');",
-																	"pm.environment.set(\"corrId\", corrId);"
+																	"pm.globals.set(\"corrId\", corrId);"
 																],
 																"type": "text/javascript"
 															}
@@ -8185,7 +8185,7 @@
 																	"});",
 																	"",
 																	"const corrId = pm.response.headers.get('X-HttPlaceholder-Correlation');",
-																	"pm.environment.set(\"corrId\", corrId);"
+																	"pm.globals.set(\"corrId\", corrId);"
 																],
 																"type": "text/javascript"
 															}
@@ -8324,7 +8324,7 @@
 															"});",
 															"",
 															"const corrId = pm.response.headers.get('X-HttPlaceholder-Correlation');",
-															"pm.environment.set(\"corrId\", corrId);"
+															"pm.globals.set(\"corrId\", corrId);"
 														],
 														"type": "text/javascript"
 													}
@@ -8433,7 +8433,7 @@
 															"});",
 															"",
 															"const corrId = pm.response.headers.get('X-HttPlaceholder-Correlation');",
-															"pm.environment.set(\"corrId\", corrId);"
+															"pm.globals.set(\"corrId\", corrId);"
 														],
 														"type": "text/javascript"
 													}
@@ -8542,6 +8542,110 @@
 															"key": "key2",
 															"value": "val2"
 														}
+													]
+												}
+											},
+											"response": []
+										}
+									]
+								},
+								{
+									"name": "Stub generation with response",
+									"item": [
+										{
+											"name": "[Create stub] Create basic stub",
+											"request": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "text/yaml",
+														"type": "text"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "id: stub-generation-with-response\ntenant: integration\nconditions:\n  method: GET\n  url:\n    path:\n      equals: /stub-generation-with-response\nresponse:\n  text: OK STUB GENERATION WITH RESPONSE"
+												},
+												"url": {
+													"raw": "{{rootUrl}}ph-api/stubs",
+													"host": [
+														"{{rootUrl}}ph-api"
+													],
+													"path": [
+														"stubs"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "Do request",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 501\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"const corrId = pm.response.headers.get('X-HttPlaceholder-Correlation');",
+															"pm.globals.set(\"corrId\", corrId);"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "GET",
+												"header": [],
+												"url": {
+													"raw": "{{rootUrl}}stub-generation-with-response",
+													"host": [
+														"{{rootUrl}}stub-generation-with-response"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "Create stub based on request",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Check generated stub\", function () {",
+															"    const jsonData = pm.response.json();",
+															"    pm.expect(jsonData.stub.response.text).to.eql(\"OK STUB GENERATION WITH RESPONSE\");",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "POST",
+												"header": [],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n    \"doNotCreateStub\": false\n}",
+													"options": {
+														"raw": {
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{rootUrl}}ph-api/requests/{{corrId}}/stubs",
+													"host": [
+														"{{rootUrl}}ph-api"
+													],
+													"path": [
+														"requests",
+														"{{corrId}}",
+														"stubs"
 													]
 												}
 											},
@@ -9735,7 +9839,7 @@
 											"script": {
 												"exec": [
 													"const corrId = pm.response.headers.get('X-HttPlaceholder-Correlation');",
-													"pm.environment.set(\"corrId\", corrId);"
+													"pm.globals.set(\"corrId\", corrId);"
 												],
 												"type": "text/javascript"
 											}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the new behavior?

From the UI it is possible to create a stub based on a request. Since it is also possible to save a response for a request (this is enabled through a setting), it is also nice that, when generating a stub based on a request, the response is also set if there is one. This has been added in this PR.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No