### PR TITLE
Bug/proxy header bug

### DIFF
--- a/src/HttPlaceholder.Application.Tests/StubExecution/ResponseWriters/ReverseProxyResponseWriterFacts.cs
+++ b/src/HttPlaceholder.Application.Tests/StubExecution/ResponseWriters/ReverseProxyResponseWriterFacts.cs
@@ -163,7 +163,8 @@ public class ReverseProxyResponseWriterFacts
             {"X-Api-Key", "abc123"},
             {"Connection", "keep-alive"},
             {HeaderKeys.AcceptEncoding, "utf-8"},
-            {"Accept", MimeTypes.JsonMime}
+            {"Accept", MimeTypes.JsonMime},
+            {"User-Agent", "WordPress/6.2.2; http://localhost:8010"}
         };
         mockHttpContextService
             .Setup(m => m.GetHeaders())
@@ -175,7 +176,7 @@ public class ReverseProxyResponseWriterFacts
             .With(r =>
             {
                 var proxyHeaders = r.Headers.ToDictionary(h => h.Key, h => h.Value.First());
-                return proxyHeaders.Count == 2 &&
+                return proxyHeaders.Count == 3 &&
                        proxyHeaders["X-Api-Key"] == "abc123" &&
                        proxyHeaders["Accept"] == MimeTypes.JsonMime;
             })

--- a/src/HttPlaceholder.Application/StubExecution/ResponseWriters/ReverseProxyResponseWriter.cs
+++ b/src/HttPlaceholder.Application/StubExecution/ResponseWriters/ReverseProxyResponseWriter.cs
@@ -78,7 +78,7 @@ internal class ReverseProxyResponseWriter : IResponseWriter, ISingletonService
         var headers = CleanHeaders(originalHeaders);
         foreach (var header in headers)
         {
-            request.Headers.Add(header.Key, header.Value);
+            request.Headers.TryAddWithoutValidation(header.Key, header.Value);
         }
 
         if (method != HttpMethod.Get)

--- a/test/HttPlaceholderIntegration.postman_collection.json
+++ b/test/HttPlaceholderIntegration.postman_collection.json
@@ -11135,6 +11135,151 @@
 									"response": []
 								}
 							]
+						},
+						{
+							"name": "Bugfix: error when setting reverse proxy header",
+							"item": [
+								{
+									"name": "Create YAML stub: proxy destination",
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "text/yaml",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "id: reverse-proxy-bugfix-destination\nconditions:\n  url:\n    path:\n      equals: /reverse-proxy-bugfix-destination\nresponse:\n  text: HELLO FROM PROXY reverse-proxy-bugfix-destination\npriority: 0\nenabled: true",
+											"options": {
+												"raw": {
+													"language": "text"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{rootUrl}}ph-api/stubs",
+											"host": [
+												"{{rootUrl}}ph-api"
+											],
+											"path": [
+												"stubs"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Create YAML stub: proxy",
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "text/yaml",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "id: reverse-proxy-bugfix\nconditions:\n  url:\n    path:\n      equals: /reverse-proxy-bugfix\nresponse:\n  reverseProxy:\n    url: {{rootUrl}}reverse-proxy-bugfix-destination\n    appendPath: true\n    appendQueryString: true\n    replaceRootUrl: true\npriority: 0\nenabled: true",
+											"options": {
+												"raw": {
+													"language": "text"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{rootUrl}}ph-api/stubs",
+											"host": [
+												"{{rootUrl}}ph-api"
+											],
+											"path": [
+												"stubs"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Perform stub request",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Body is correct\", function () {",
+													"    pm.response.to.have.body(\"HELLO FROM PROXY reverse-proxy-bugfix-destination\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "User-Agent",
+												"value": "WordPress/6.2.2; http://localhost:8010",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{rootUrl}}reverse-proxy-bugfix",
+											"host": [
+												"{{rootUrl}}reverse-proxy-bugfix"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Check request",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Check request\", function () {",
+													"    var jsonData = pm.response.json();",
+													"    const request = jsonData.find(d => d.requestParameters.url.endsWith(\"/reverse-proxy-bugfix-destination\"));",
+													"    pm.expect(!!request).to.be.true;",
+													"    pm.expect(request.requestParameters.headers[\"User-Agent\"]).to.eql(\"WordPress/6.2.2; http://localhost:8010\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "User-Agent",
+												"value": "WordPress/6.2.2; http://localhost:8010",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{rootUrl}}ph-api/requests",
+											"host": [
+												"{{rootUrl}}ph-api"
+											],
+											"path": [
+												"requests"
+											]
+										}
+									},
+									"response": []
+								}
+							]
 						}
 					]
 				}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the new behavior?

- Fixed bug where some header values were not accepted by the .NET HttpClient when a reverse proxy was used. An example is the `User-Agent` value `WordPress/6.2.2; http://localhost:8010`.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No
