### PR TITLE
Check if body is set before writing to response

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+[2023.7.22]
+- Fixed bug where an exception was thrown when running a proxy and an HTTP was returned by the (https://github.com/dukeofharen/httplaceholder/pull/317).
+
 [2023.7.7]
 - Fixed bug where some header values were not accepted by the .NET HttpClient when a reverse proxy was used. An example is the `User-Agent` value `WordPress/6.2.2; http://localhost:8010` (https://github.com/dukeofharen/httplaceholder/pull/314).
 - The self-signed certificate for HTTPS traffic has been replaced (https://github.com/dukeofharen/httplaceholder/pull/315).

--- a/src/HttPlaceholder.Web.Shared/Middleware/StubHandlingMiddleware.cs
+++ b/src/HttPlaceholder.Web.Shared/Middleware/StubHandlingMiddleware.cs
@@ -109,9 +109,9 @@ public class StubHandlingMiddleware
 
     private void HandleException(string correlationId, Exception e)
     {
+        _logger.LogWarning($"Unexpected exception thrown: {e}");
         _httpContextService.SetStatusCode(HttpStatusCode.InternalServerError);
         _httpContextService.TryAddHeader(HeaderKeys.XHttPlaceholderCorrelation, correlationId);
-        _logger.LogWarning($"Unexpected exception thrown: {e}");
     }
 
     private async Task HandleRequestValidationException(string correlation, RequestValidationException e,
@@ -165,7 +165,7 @@ public class StubHandlingMiddleware
             _httpContextService.AddHeader(key, value);
         }
 
-        if (response.Body != null)
+        if (response.Body != null && response.Body.Any())
         {
             await _httpContextService.WriteAsync(response.Body, cancellationToken);
         }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

An exception is thrown when using the reverse proxy response writer and the called server returns an HTTP 204. An empty body is written to the response, which is not allowed by .NET, which results in an exception.

## What is the new behavior?

At first, a check was done that the returned response is not null before writing the stub response. Since an empty body is not null, the empty body was written and an exception was thrown. Now, we also check whether the body has contents before writing it to the response.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No
