### PR TITLE
Feature/display root url setting

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 - Fixed bug where HttPlaceholder would insert an incorrect value in the response if the "scenario_state" or the "scenario_hitcount" were used (https://github.com/dukeofharen/httplaceholder/pull/318).
 - Made several infrastructure changes to the code (https://github.com/dukeofharen/httplaceholder/pull/320).
 - Added AuditBehavior which logs all the interactions between the web API and the application layer using MediatR (only in verbose logging mode) (https://github.com/dukeofharen/httplaceholder/pull/320).
+- Added new `publicUrl` property which makes it possible to assign a root URL for both HttPlaceholder and the UI. Useful if you run HttPlaceholder behind a reverse proxy (https://github.com/dukeofharen/httplaceholder/pull/321).
 
 # BREAKING CHANGES
 

--- a/docker/httplaceholder-with-file-storage/docker-compose.yml
+++ b/docker/httplaceholder-with-file-storage/docker-compose.yml
@@ -4,13 +4,12 @@ services:
   httplaceholder:
     image: dukeofharen/httplaceholder:latest
     environment:
-      fileStorageLocation: '/etc/httplaceholder'
       verbose: 'true'
     ports:
-      - 5000:5000
+      - "5000:5000"
     restart: on-failure
     volumes:
-      - stub_data:/etc/httplaceholder
+      - stub_data:/root/.httplaceholder
 
 volumes:
   stub_data:

--- a/docker/httplaceholder-with-mariadb/docker-compose.yml
+++ b/docker/httplaceholder-with-mariadb/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       mysqlConnectionString: 'Server=mariadb;Database=httplaceholder;Uid=httplaceholder;Pwd=httplaceholder;Allow User Variables=true'
       verbose: 'true'
     ports:
-      - 5000:5000
+      - "5000:5000"
     restart: on-failure
   mariadb:
     image: mariadb:10
@@ -19,7 +19,7 @@ services:
       MYSQL_USER: httplaceholder
       MYSQL_PASSWORD: httplaceholder
     ports:
-      - 3306:3306
+      - "3306:3306"
     volumes:
       - mariadb_data:/var/lib/mysql
 

--- a/docker/httplaceholder-with-mssql/docker-compose.yml
+++ b/docker/httplaceholder-with-mssql/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       sqlServerConnectionString: 'Server=mssql,1433;Database=httplaceholder;User Id=sa;Password=Password123!'
       verbose: 'true'
     ports:
-      - 5000:5000
+      - "5000:5000"
     restart: on-failure
   mssql:
     image: mcr.microsoft.com/mssql/server:2019-latest
@@ -18,7 +18,7 @@ services:
       SA_PASSWORD: Password123!
       MSSQL_PID: Developer
     ports:
-      - 1433:1433
+      - "1433:1433"
     volumes:
       - mssql_data:/var/opt/mssql
       - ./initscripts:/usr/local/bin/initscripts

--- a/docker/httplaceholder-with-mysql5/docker-compose.yml
+++ b/docker/httplaceholder-with-mysql5/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       mysqlConnectionString: 'Server=mysql;Database=httplaceholder;Uid=httplaceholder;Pwd=httplaceholder;Allow User Variables=true;SSL Mode=None'
       verbose: 'true'
     ports:
-      - 5000:5000
+      - "5000:5000"
     restart: on-failure
   mysql:
     image: mysql:5
@@ -19,7 +19,7 @@ services:
       MYSQL_USER: httplaceholder
       MYSQL_PASSWORD: httplaceholder
     ports:
-      - 3306:3306
+      - "3306:3306"
     volumes:
       - mysql5_data:/var/lib/mysql
 

--- a/docker/httplaceholder-with-mysql8/docker-compose.yml
+++ b/docker/httplaceholder-with-mysql8/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       mysqlConnectionString: 'Server=mysql;Database=httplaceholder;Uid=httplaceholder;Pwd=httplaceholder;Allow User Variables=true'
       verbose: 'true'
     ports:
-      - 5000:5000
+      - "5000:5000"
     restart: on-failure
   mysql:
     image: mysql:8
@@ -19,7 +19,7 @@ services:
       MYSQL_USER: httplaceholder
       MYSQL_PASSWORD: httplaceholder
     ports:
-      - 3306:3306
+      - "3306:3306"
     volumes:
       - mysql8_data:/var/lib/mysql
 

--- a/docker/httplaceholder-with-reverse-proxy/docker-compose.yml
+++ b/docker/httplaceholder-with-reverse-proxy/docker-compose.yml
@@ -1,0 +1,23 @@
+# A Docker Compose example that starts HttPlaceholder with a file storage location and uses Nginx as reverse proxy.
+# HttPlaceholder can, when the Docker containers are started, be reached on http://localhost/httplaceholder and the UI on http://localhost/httplaceholder/ph-ui.
+version: '3.8'
+services:
+  httplaceholder:
+    image: dukeofharen/httplaceholder:latest
+    environment:
+      verbose: 'true'
+      publicUrl: 'http://localhost/httplaceholder'
+    restart: on-failure
+    volumes:
+      - stub_data:/root/.httplaceholder
+  nginx:
+    image: nginx:1.25.2
+    depends_on:
+      - httplaceholder
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf
+    ports:
+      - "80:80"
+
+volumes:
+  stub_data:

--- a/docker/httplaceholder-with-reverse-proxy/nginx.conf
+++ b/docker/httplaceholder-with-reverse-proxy/nginx.conf
@@ -1,0 +1,51 @@
+events {
+        worker_connections  4096;
+}
+
+http {
+        map $http_host $port {
+                default 80;
+                "~^[^\:]+:(?<p>\d+)$" $p;
+        }
+        
+        server {
+                listen 80;
+
+                location /httplaceholder {
+                        rewrite ^/httplaceholder(/.*)$ $1 break;
+                        proxy_pass http://httplaceholder:5000;
+                        proxy_set_header Host $host;
+                        proxy_set_header X-Real-IP $remote_addr;
+                        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                        proxy_set_header X-Forwarded-Host $host:$port;
+                        proxy_set_header X-Forwarded-Proto $scheme;
+                }
+                
+                location /httplaceholder/requestHub {
+                        rewrite ^/httplaceholder(/.*)$ $1 break;
+                        proxy_pass http://httplaceholder:5000/requestHub;
+                        proxy_http_version 1.1;
+                        proxy_set_header Upgrade $http_upgrade;
+                        proxy_set_header Connection "Upgrade";
+                        proxy_set_header Host $host;
+                }
+                
+                location /httplaceholder/scenarioHub {
+                        rewrite ^/httplaceholder(/.*)$ $1 break;
+                        proxy_pass http://httplaceholder:5000/scenarioHub;
+                        proxy_http_version 1.1;
+                        proxy_set_header Upgrade $http_upgrade;
+                        proxy_set_header Connection "Upgrade";
+                        proxy_set_header Host $host;
+                }
+            
+                location /httplaceholder/stubHub {
+                        rewrite ^/httplaceholder(/.*)$ $1 break;
+                        proxy_pass http://httplaceholder:5000/stubHub;
+                        proxy_http_version 1.1;
+                        proxy_set_header Upgrade $http_upgrade;
+                        proxy_set_header Connection "Upgrade";
+                        proxy_set_header Host $host;
+                }
+        }
+}

--- a/docker/httplaceholder-with-sqlite/docker-compose.yml
+++ b/docker/httplaceholder-with-sqlite/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       sqliteConnectionString: 'Data Source=/etc/httplaceholder/httplaceholder.db'
       verbose: 'true'
     ports:
-      - 5000:5000
+      - "5000:5000"
     restart: on-failure
     volumes:
       - sqlite_data:/etc/httplaceholder

--- a/docker/httplaceholder-with-stub-files/docker-compose.yml
+++ b/docker/httplaceholder-with-stub-files/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       useInMemoryStorage: 'true'
       verbose: 'true'
     ports:
-      - 5000:5000
+      - "5000:5000"
     restart: on-failure
     volumes:
       - ./stubs:/etc/httplaceholder

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -2410,6 +2410,14 @@ httplaceholder --readProxyHeaders false
 
 By disabling the reading of the proxy headers, the IP, host and protocol as received by the client are always used.
 
+### Public URL
+
+When running HttPlaceholder behind a reverse proxy, you should set the public URL. This makes sure that requests made by the [UI](#management-interface) will succeed and the value written by the [root URL variable parser](#root-url) is correct. This is not needed when not running behind a reverse proxy.
+
+```bash
+httplaceholder --publicUrl https://example.com/stubs
+```
+
 ## Authentication
 
 ### REST API Authentication (optional)

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -2412,7 +2412,7 @@ By disabling the reading of the proxy headers, the IP, host and protocol as rece
 
 ### Public URL
 
-When running HttPlaceholder behind a reverse proxy, you should set the public URL. This makes sure that requests made by the [UI](#management-interface) will succeed and the value written by the [root URL variable parser](#root-url) is correct. This is not needed when not running behind a reverse proxy.
+When running HttPlaceholder behind a reverse proxy, you should set the public URL. This makes sure that requests made by the [UI](#management-interface) will succeed and the value written by the [root URL variable parser](#root-url) and [display URL variable parser](#display-url) is correct. This is not needed when not running behind a reverse proxy.
 
 ```bash
 httplaceholder --publicUrl https://example.com/stubs

--- a/gui/index.html
+++ b/gui/index.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" href="favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<head>
+    <meta charset="UTF-8"/>
+    <link rel="icon" href="favicon.ico"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>HttPlaceholder</title>
-  </head>
-  <body>
-    <div id="app"></div>
-    <script type="module" src="/src/main.ts"></script>
-  </body>
+</head>
+<body>
+<div id="app"></div>
+<script type="module" src="/src/main.ts"></script>
+</body>
 </html>

--- a/gui/src/plugins/api.ts
+++ b/gui/src/plugins/api.ts
@@ -1,5 +1,6 @@
 import { addBeforeSendHandler, setDefaultRequestOptions } from "@/utils/api";
 import { useUsersStore } from "@/store/users";
+import { getRootUrl } from "@/utils/config";
 
 addBeforeSendHandler((url: string, request: RequestInit) => {
   const usersStore = useUsersStore();
@@ -12,5 +13,5 @@ addBeforeSendHandler((url: string, request: RequestInit) => {
 
 setDefaultRequestOptions({
   headers: undefined,
-  rootUrl: (window as any).rootUrl ?? "",
+  rootUrl: getRootUrl(),
 });

--- a/gui/src/plugins/api.ts
+++ b/gui/src/plugins/api.ts
@@ -1,4 +1,4 @@
-import { addBeforeSendHandler } from "@/utils/api";
+import { addBeforeSendHandler, setDefaultRequestOptions } from "@/utils/api";
 import { useUsersStore } from "@/store/users";
 
 addBeforeSendHandler((url: string, request: RequestInit) => {
@@ -8,4 +8,9 @@ addBeforeSendHandler((url: string, request: RequestInit) => {
   if (token && !headerKeys.find((k) => k.toLowerCase() === "authorization")) {
     (request.headers as any).Authorization = `Basic ${token}`;
   }
+});
+
+setDefaultRequestOptions({
+  headers: undefined,
+  rootUrl: (window as any).rootUrl ?? "",
 });

--- a/gui/src/utils/api.ts
+++ b/gui/src/utils/api.ts
@@ -5,6 +5,7 @@ import { useHttpStore } from "@/store/http";
 
 export interface RequestOptions {
   headers: object | undefined;
+  rootUrl: string | undefined;
 }
 
 export interface PreparedRequest {
@@ -51,8 +52,15 @@ const handleError = (error: any): void => {
 };
 
 const determineRequestOptions = (
-  requestOptions: RequestOptions
+  requestOptions: RequestOptions | undefined
 ): RequestOptions => {
+  if (!requestOptions) {
+    requestOptions = {
+      headers: {},
+      rootUrl: "",
+    };
+  }
+
   if (!defaultRequestOptions) {
     return requestOptions;
   }
@@ -96,13 +104,8 @@ export function setDefaultRequestOptions(options: RequestOptions) {
   defaultRequestOptions = options;
 }
 
-export function get(url: string, options?: RequestOptions): Promise<any> {
-  options = determineRequestOptions(
-    options || {
-      headers: {},
-    }
-  );
-  console.log(options);
+export async function get(url: string, options?: RequestOptions): Promise<any> {
+  options = determineRequestOptions(options);
   const request = <RequestInit>{
     method: "GET",
     headers: options.headers || {},
@@ -110,15 +113,16 @@ export function get(url: string, options?: RequestOptions): Promise<any> {
   handleBeforeSend(url, request);
   const httpSore = useHttpStore();
   httpSore.increaseNumberOfCurrentHttpCalls();
-  return fetch(url, request).then(handleResponse).catch(handleError);
+  try {
+    const response = await fetch(url, request);
+    return await handleResponse(response);
+  } catch (error) {
+    return handleError(error);
+  }
 }
 
-export function del(url: string, options?: RequestOptions): Promise<any> {
-  options = determineRequestOptions(
-    options || {
-      headers: {},
-    }
-  );
+export async function del(url: string, options?: RequestOptions): Promise<any> {
+  options = determineRequestOptions(options);
   const request = <RequestInit>{
     method: "DELETE",
     headers: options.headers || {},
@@ -126,20 +130,21 @@ export function del(url: string, options?: RequestOptions): Promise<any> {
   handleBeforeSend(url, request);
   const httpSore = useHttpStore();
   httpSore.increaseNumberOfCurrentHttpCalls();
-  return fetch(url, request).then(handleResponse).catch(handleError);
+  try {
+    const response = await fetch(url, request);
+    return await handleResponse(response);
+  } catch (error) {
+    return handleError(error);
+  }
 }
 
-export function put(
+export async function put(
   url: string,
   body: any,
   options?: RequestOptions
 ): Promise<any> {
   const preparedRequest = prepareRequest(body);
-  options = determineRequestOptions(
-    options || {
-      headers: {},
-    }
-  );
+  options = determineRequestOptions(options);
   const headers = Object.assign(
     { "content-type": preparedRequest.contentType },
     options.headers || {}
@@ -152,20 +157,21 @@ export function put(
   handleBeforeSend(url, request);
   const httpSore = useHttpStore();
   httpSore.increaseNumberOfCurrentHttpCalls();
-  return fetch(url, request).then(handleResponse).catch(handleError);
+  try {
+    const response = await fetch(url, request);
+    return await handleResponse(response);
+  } catch (error) {
+    return handleError(error);
+  }
 }
 
-export function post(
+export async function post(
   url: string,
   body: any,
   options?: RequestOptions
 ): Promise<any> {
   const preparedRequest = prepareRequest(body);
-  options = determineRequestOptions(
-    options || {
-      headers: {},
-    }
-  );
+  options = determineRequestOptions(options);
   const headers = Object.assign(
     { "content-type": preparedRequest.contentType },
     options.headers || {}
@@ -178,20 +184,21 @@ export function post(
   handleBeforeSend(url, request);
   const httpSore = useHttpStore();
   httpSore.increaseNumberOfCurrentHttpCalls();
-  return fetch(url, request).then(handleResponse).catch(handleError);
+  try {
+    const response = await fetch(url, request);
+    return await handleResponse(response);
+  } catch (error) {
+    return handleError(error);
+  }
 }
 
-export function patch(
+export async function patch(
   url: string,
   body: any,
   options?: RequestOptions
 ): Promise<any> {
   const preparedRequest = prepareRequest(body);
-  options = determineRequestOptions(
-    options || {
-      headers: {},
-    }
-  );
+  options = determineRequestOptions(options);
   const headers = Object.assign(
     { "content-type": preparedRequest.contentType },
     options.headers || {}
@@ -204,5 +211,10 @@ export function patch(
   handleBeforeSend(url, request);
   const httpSore = useHttpStore();
   httpSore.increaseNumberOfCurrentHttpCalls();
-  return fetch(url, request).then(handleResponse).catch(handleError);
+  try {
+    const response = await fetch(url, request);
+    return await handleResponse(response);
+  } catch (error) {
+    return handleError(error);
+  }
 }

--- a/gui/src/utils/api.ts
+++ b/gui/src/utils/api.ts
@@ -5,7 +5,7 @@ import { useHttpStore } from "@/store/http";
 
 export interface RequestOptions {
   headers: object | undefined;
-  rootUrl: string | undefined;
+  rootUrl?: string;
 }
 
 export interface PreparedRequest {

--- a/gui/src/utils/api.ts
+++ b/gui/src/utils/api.ts
@@ -1,5 +1,6 @@
 type BeforeSendHandler = { (url: string, request: RequestInit): void };
 const beforeSendHandlers: BeforeSendHandler[] = [];
+let defaultRequestOptions: RequestOptions | undefined;
 import { useHttpStore } from "@/store/http";
 
 export interface RequestOptions {
@@ -49,6 +50,18 @@ const handleError = (error: any): void => {
   throw error;
 };
 
+const determineRequestOptions = (
+  requestOptions: RequestOptions
+): RequestOptions => {
+  if (!defaultRequestOptions) {
+    return requestOptions;
+  }
+
+  return {
+    headers: { ...defaultRequestOptions.headers, ...requestOptions.headers },
+  } as RequestOptions;
+};
+
 function prepareRequest(input: any): PreparedRequest {
   switch (typeof input) {
     case "string":
@@ -79,10 +92,17 @@ export function addBeforeSendHandler(action: BeforeSendHandler): void {
   beforeSendHandlers.push(action);
 }
 
+export function setDefaultRequestOptions(options: RequestOptions) {
+  defaultRequestOptions = options;
+}
+
 export function get(url: string, options?: RequestOptions): Promise<any> {
-  options = options || {
-    headers: {},
-  };
+  options = determineRequestOptions(
+    options || {
+      headers: {},
+    }
+  );
+  console.log(options);
   const request = <RequestInit>{
     method: "GET",
     headers: options.headers || {},
@@ -94,9 +114,11 @@ export function get(url: string, options?: RequestOptions): Promise<any> {
 }
 
 export function del(url: string, options?: RequestOptions): Promise<any> {
-  options = options || {
-    headers: {},
-  };
+  options = determineRequestOptions(
+    options || {
+      headers: {},
+    }
+  );
   const request = <RequestInit>{
     method: "DELETE",
     headers: options.headers || {},
@@ -113,9 +135,11 @@ export function put(
   options?: RequestOptions
 ): Promise<any> {
   const preparedRequest = prepareRequest(body);
-  options = options || {
-    headers: {},
-  };
+  options = determineRequestOptions(
+    options || {
+      headers: {},
+    }
+  );
   const headers = Object.assign(
     { "content-type": preparedRequest.contentType },
     options.headers || {}
@@ -137,9 +161,11 @@ export function post(
   options?: RequestOptions
 ): Promise<any> {
   const preparedRequest = prepareRequest(body);
-  options = options || {
-    headers: {},
-  };
+  options = determineRequestOptions(
+    options || {
+      headers: {},
+    }
+  );
   const headers = Object.assign(
     { "content-type": preparedRequest.contentType },
     options.headers || {}
@@ -161,9 +187,11 @@ export function patch(
   options?: RequestOptions
 ): Promise<any> {
   const preparedRequest = prepareRequest(body);
-  options = options || {
-    headers: {},
-  };
+  options = determineRequestOptions(
+    options || {
+      headers: {},
+    }
+  );
   const headers = Object.assign(
     { "content-type": preparedRequest.contentType },
     options.headers || {}

--- a/gui/src/utils/api.ts
+++ b/gui/src/utils/api.ts
@@ -67,6 +67,7 @@ const determineRequestOptions = (
 
   return {
     headers: { ...defaultRequestOptions.headers, ...requestOptions.headers },
+    rootUrl: defaultRequestOptions.rootUrl ?? requestOptions.rootUrl ?? "",
   } as RequestOptions;
 };
 

--- a/gui/src/utils/api.ts
+++ b/gui/src/utils/api.ts
@@ -70,6 +70,14 @@ const determineRequestOptions = (
   } as RequestOptions;
 };
 
+const determineUrl = (options: RequestOptions, url: string) => {
+  if (!options.rootUrl) {
+    return url;
+  }
+
+  return options.rootUrl + url;
+};
+
 function prepareRequest(input: any): PreparedRequest {
   switch (typeof input) {
     case "string":
@@ -110,6 +118,7 @@ export async function get(url: string, options?: RequestOptions): Promise<any> {
     method: "GET",
     headers: options.headers || {},
   };
+  url = determineUrl(options, url);
   handleBeforeSend(url, request);
   const httpSore = useHttpStore();
   httpSore.increaseNumberOfCurrentHttpCalls();
@@ -127,6 +136,7 @@ export async function del(url: string, options?: RequestOptions): Promise<any> {
     method: "DELETE",
     headers: options.headers || {},
   };
+  url = determineUrl(options, url);
   handleBeforeSend(url, request);
   const httpSore = useHttpStore();
   httpSore.increaseNumberOfCurrentHttpCalls();
@@ -154,6 +164,7 @@ export async function put(
     headers,
     body: preparedRequest.body,
   };
+  url = determineUrl(options, url);
   handleBeforeSend(url, request);
   const httpSore = useHttpStore();
   httpSore.increaseNumberOfCurrentHttpCalls();
@@ -181,6 +192,7 @@ export async function post(
     headers,
     body: preparedRequest.body,
   };
+  url = determineUrl(options, url);
   handleBeforeSend(url, request);
   const httpSore = useHttpStore();
   httpSore.increaseNumberOfCurrentHttpCalls();
@@ -208,6 +220,7 @@ export async function patch(
     headers,
     body: preparedRequest.body,
   };
+  url = determineUrl(options, url);
   handleBeforeSend(url, request);
   const httpSore = useHttpStore();
   httpSore.increaseNumberOfCurrentHttpCalls();

--- a/gui/src/utils/config.ts
+++ b/gui/src/utils/config.ts
@@ -1,0 +1,3 @@
+export function getRootUrl(): string {
+  return (window as any).rootUrl ?? "";
+}

--- a/gui/src/views/Requests.vue
+++ b/gui/src/views/Requests.vue
@@ -120,6 +120,7 @@ import type { RequestOverviewModel } from "@/domain/request/request-overview-mod
 import type { RequestSavedFilterModel } from "@/domain/request-saved-filter-model";
 import { useConfigurationStore } from "@/store/configuration";
 import type { ConfigurationModel } from "@/domain/stub/configuration-model";
+import { getRootUrl } from "@/utils/config";
 
 export default defineComponent({
   name: "Requests",
@@ -160,7 +161,7 @@ export default defineComponent({
     // Functions
     const initializeSignalR = async () => {
       signalrConnection = new HubConnectionBuilder()
-        .withUrl("/requestHub")
+        .withUrl(`${getRootUrl()}/requestHub`)
         .build();
       signalrConnection.on(
         "RequestReceived",

--- a/gui/src/views/Scenarios.vue
+++ b/gui/src/views/Scenarios.vue
@@ -74,6 +74,7 @@ import { useScenariosStore } from "@/store/scenarios";
 import { defineComponent } from "vue";
 import type { ScenarioModel } from "@/domain/scenario/scenario-model";
 import { HubConnection, HubConnectionBuilder } from "@microsoft/signalr";
+import { getRootUrl } from "@/utils/config";
 
 export default defineComponent({
   name: "Scenarios",
@@ -101,7 +102,7 @@ export default defineComponent({
     // Functions
     const initializeSignalR = async () => {
       signalrConnection = new HubConnectionBuilder()
-        .withUrl("/scenarioHub")
+        .withUrl(`${getRootUrl()}/scenarioHub`)
         .build();
       signalrConnection.on("ScenarioSet", (scenario: ScenarioModel) => {
         const foundScenario = scenarios.value.find(

--- a/gui/src/views/Stubs.vue
+++ b/gui/src/views/Stubs.vue
@@ -186,6 +186,7 @@ import type { StubSavedFilterModel } from "@/domain/stub-saved-filter-model";
 import dayjs from "dayjs";
 import { vsprintf } from "sprintf-js";
 import { HubConnection, HubConnectionBuilder } from "@microsoft/signalr";
+import { getRootUrl } from "@/utils/config";
 
 export default defineComponent({
   name: "Stubs",
@@ -249,7 +250,7 @@ export default defineComponent({
 
     const initializeSignalR = async () => {
       signalrConnection = new HubConnectionBuilder()
-        .withUrl("/stubHub")
+        .withUrl(`${getRootUrl()}/stubHub`)
         .build();
       signalrConnection.on("StubAdded", (stub: FullStubOverviewModel) => {
         if (!stubs.value.find((s) => s.stub.id === stub.stub.id)) {

--- a/src/.run/HttPlaceholder (file storage).run.xml
+++ b/src/.run/HttPlaceholder (file storage).run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="HttPlaceholder (file storage)" type="DotNetProject" factoryName=".NET Project">
     <option name="EXE_PATH" value="$PROJECT_DIR$/HttPlaceholder/bin/Debug/net7.0/HttPlaceholder" />
-    <option name="PROGRAM_PARAMETERS" value="-V --fileStorageLocation $USER_HOME$/CodeMetadata/httplaceholder/stubsRoot --oldRequestsQueueLength 100" />
+    <option name="PROGRAM_PARAMETERS" value="-V --fileStorageLocation $USER_HOME$/CodeMetadata/httplaceholder/stubsRoot --oldRequestsQueueLength 100 --publicUrl https://example.com/stubs" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/HttPlaceholder" />
     <option name="PASS_PARENT_ENVS" value="1" />
     <envs>

--- a/src/.run/HttPlaceholder (file storage).run.xml
+++ b/src/.run/HttPlaceholder (file storage).run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="HttPlaceholder (file storage)" type="DotNetProject" factoryName=".NET Project">
     <option name="EXE_PATH" value="$PROJECT_DIR$/HttPlaceholder/bin/Debug/net7.0/HttPlaceholder" />
-    <option name="PROGRAM_PARAMETERS" value="-V --fileStorageLocation $USER_HOME$/CodeMetadata/httplaceholder/stubsRoot --oldRequestsQueueLength 100 --publicUrl https://example.com/stubs" />
+    <option name="PROGRAM_PARAMETERS" value="-V --fileStorageLocation $USER_HOME$/CodeMetadata/httplaceholder/stubsRoot --oldRequestsQueueLength 100" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/HttPlaceholder" />
     <option name="PASS_PARENT_ENVS" value="1" />
     <envs>

--- a/src/HttPlaceholder.Application.Tests/Infrastructure/MediatR/AuditBehaviorFacts.cs
+++ b/src/HttPlaceholder.Application.Tests/Infrastructure/MediatR/AuditBehaviorFacts.cs
@@ -12,11 +12,11 @@ namespace HttPlaceholder.Application.Tests.Infrastructure.MediatR;
 [TestClass]
 public class AuditBehaviorFacts
 {
-    private readonly TestResponse _response = new() {Output = "Output"};
+    private readonly MockLogger<AuditBehavior<TestRequest, TestResponse>> _logger = new();
 
     private readonly AutoMocker _mocker = new();
+    private readonly TestResponse _response = new() {Output = "Output"};
     private readonly SettingsModel _settings = new() {Logging = new LoggingSettingsModel()};
-    private readonly MockLogger<AuditBehavior<TestRequest, TestResponse>> _logger = new();
 
     [TestInitialize]
     public void Setup()
@@ -61,10 +61,7 @@ public class AuditBehaviorFacts
             .Returns(ip);
 
         // Act
-        var result = await behavior.Handle(new TestRequest
-        {
-            Input = "Input"
-        }, () =>
+        var result = await behavior.Handle(new TestRequest {Input = "Input"}, () =>
         {
             nextCalled = true;
             return Task.FromResult(_response);
@@ -98,10 +95,7 @@ Duration: 0 ms"));
             .Returns(ip);
 
         // Act
-        await Assert.ThrowsExceptionAsync<Exception>(() => behavior.Handle(new TestRequest
-        {
-            Input = "Input"
-        }, () =>
+        await Assert.ThrowsExceptionAsync<Exception>(() => behavior.Handle(new TestRequest {Input = "Input"}, () =>
         {
             nextCalled = true;
             throw new Exception("ERROR!");

--- a/src/HttPlaceholder.Application.Tests/Requests/Queries/GetAllRequestsQueryHandlerFacts.cs
+++ b/src/HttPlaceholder.Application.Tests/Requests/Queries/GetAllRequestsQueryHandlerFacts.cs
@@ -42,7 +42,9 @@ public class GetAllRequestsQueryHandlerFacts
         var response = Array.Empty<RequestResultModel>();
         var stubContextMock = _mocker.GetMock<IStubContext>();
         stubContextMock
-            .Setup(m => m.GetRequestResultsAsync(It.Is<PagingModel>(p => p.FromIdentifier == "abc123" && !p.ItemsPerPage.HasValue), It.IsAny<CancellationToken>()))
+            .Setup(m => m.GetRequestResultsAsync(
+                It.Is<PagingModel>(p => p.FromIdentifier == "abc123" && !p.ItemsPerPage.HasValue),
+                It.IsAny<CancellationToken>()))
             .ReturnsAsync(response);
 
         // Act
@@ -62,7 +64,9 @@ public class GetAllRequestsQueryHandlerFacts
         var response = Array.Empty<RequestResultModel>();
         var stubContextMock = _mocker.GetMock<IStubContext>();
         stubContextMock
-            .Setup(m => m.GetRequestResultsAsync(It.Is<PagingModel>(p => p.FromIdentifier == "abc123" && p.ItemsPerPage == 2), It.IsAny<CancellationToken>()))
+            .Setup(m => m.GetRequestResultsAsync(
+                It.Is<PagingModel>(p => p.FromIdentifier == "abc123" && p.ItemsPerPage == 2),
+                It.IsAny<CancellationToken>()))
             .ReturnsAsync(response);
 
         // Act

--- a/src/HttPlaceholder.Application.Tests/Requests/Queries/GetRequestsOverviewQueryHandlerFacts.cs
+++ b/src/HttPlaceholder.Application.Tests/Requests/Queries/GetRequestsOverviewQueryHandlerFacts.cs
@@ -1,5 +1,4 @@
-﻿using HttPlaceholder.Application.Requests.Queries.GetAllRequests;
-using HttPlaceholder.Application.Requests.Queries.GetRequestsOverview;
+﻿using HttPlaceholder.Application.Requests.Queries.GetRequestsOverview;
 using HttPlaceholder.Application.StubExecution;
 using HttPlaceholder.Application.StubExecution.Models;
 
@@ -43,7 +42,9 @@ public class GetRequestsOverviewQueryHandlerFacts
         var response = Array.Empty<RequestOverviewModel>();
         var stubContextMock = _mocker.GetMock<IStubContext>();
         stubContextMock
-            .Setup(m => m.GetRequestResultsOverviewAsync(It.Is<PagingModel>(p => p.FromIdentifier == "abc123" && !p.ItemsPerPage.HasValue), It.IsAny<CancellationToken>()))
+            .Setup(m => m.GetRequestResultsOverviewAsync(
+                It.Is<PagingModel>(p => p.FromIdentifier == "abc123" && !p.ItemsPerPage.HasValue),
+                It.IsAny<CancellationToken>()))
             .ReturnsAsync(response);
 
         // Act
@@ -63,7 +64,9 @@ public class GetRequestsOverviewQueryHandlerFacts
         var response = Array.Empty<RequestOverviewModel>();
         var stubContextMock = _mocker.GetMock<IStubContext>();
         stubContextMock
-            .Setup(m => m.GetRequestResultsOverviewAsync(It.Is<PagingModel>(p => p.FromIdentifier == "abc123" && p.ItemsPerPage == 2), It.IsAny<CancellationToken>()))
+            .Setup(m => m.GetRequestResultsOverviewAsync(
+                It.Is<PagingModel>(p => p.FromIdentifier == "abc123" && p.ItemsPerPage == 2),
+                It.IsAny<CancellationToken>()))
             .ReturnsAsync(response);
 
         // Act

--- a/src/HttPlaceholder.Application.Tests/StubExecution/Implementations/StubContextFacts.cs
+++ b/src/HttPlaceholder.Application.Tests/StubExecution/Implementations/StubContextFacts.cs
@@ -177,7 +177,8 @@ public class StubContextFacts
 
         // assert
         stubSource.Verify(m => m.AddStubAsync(stubToBeAdded, It.IsAny<CancellationToken>()), Times.Once);
-        stubNotifyMock.Verify(m => m.StubAddedAsync(It.Is<FullStubOverviewModel>(s => s.Stub.Id == stubToBeAdded.Id), It.IsAny<CancellationToken>()));
+        stubNotifyMock.Verify(m => m.StubAddedAsync(It.Is<FullStubOverviewModel>(s => s.Stub.Id == stubToBeAdded.Id),
+            It.IsAny<CancellationToken>()));
     }
 
     [TestMethod]
@@ -615,11 +616,17 @@ public class StubContextFacts
             Times.Once);
         stubSource.Verify(m => m.AddStubAsync(It.Is<StubModel>(s => s.Id == stub3.Id), It.IsAny<CancellationToken>()),
             Times.Once);
-        stubNotifyMock.Verify(m => m.StubAddedAsync(It.Is<FullStubOverviewModel>(s => s.Stub.Id == stub1.Id), It.IsAny<CancellationToken>()),
+        stubNotifyMock.Verify(
+            m => m.StubAddedAsync(It.Is<FullStubOverviewModel>(s => s.Stub.Id == stub1.Id),
+                It.IsAny<CancellationToken>()),
             Times.Never);
-        stubNotifyMock.Verify(m => m.StubAddedAsync(It.Is<FullStubOverviewModel>(s => s.Stub.Id == stub2.Id), It.IsAny<CancellationToken>()),
+        stubNotifyMock.Verify(
+            m => m.StubAddedAsync(It.Is<FullStubOverviewModel>(s => s.Stub.Id == stub2.Id),
+                It.IsAny<CancellationToken>()),
             Times.Once);
-        stubNotifyMock.Verify(m => m.StubAddedAsync(It.Is<FullStubOverviewModel>(s => s.Stub.Id == stub3.Id), It.IsAny<CancellationToken>()),
+        stubNotifyMock.Verify(
+            m => m.StubAddedAsync(It.Is<FullStubOverviewModel>(s => s.Stub.Id == stub3.Id),
+                It.IsAny<CancellationToken>()),
             Times.Once);
 
         Assert.IsTrue(newStubs.All(s => s.Tenant == tenant1));

--- a/src/HttPlaceholder.Application.Tests/StubExecution/Implementations/StubRequestExecutorFacts.cs
+++ b/src/HttPlaceholder.Application.Tests/StubExecution/Implementations/StubRequestExecutorFacts.cs
@@ -200,6 +200,7 @@ public class StubRequestExecutorFacts
         _mocker.GetMock<IScenarioService>()
             .Verify(m => m.IncreaseHitCountAsync(_stub2.Stub.Scenario, It.IsAny<CancellationToken>()));
         _mocker.GetMock<IMediator>()
-            .Verify(m => m.Publish(It.Is<BeforeStubResponseReturnedNotification>(n => n.Response == response), It.IsAny<CancellationToken>()));
+            .Verify(m => m.Publish(It.Is<BeforeStubResponseReturnedNotification>(n => n.Response == response),
+                It.IsAny<CancellationToken>()));
     }
 }

--- a/src/HttPlaceholder.Application.Tests/StubExecution/Models/HttpResponseModelFacts.cs
+++ b/src/HttPlaceholder.Application.Tests/StubExecution/Models/HttpResponseModelFacts.cs
@@ -1,5 +1,4 @@
-﻿using System.Text;
-using AutoMapper;
+﻿using AutoMapper;
 using HttPlaceholder.Application.StubExecution.Models;
 
 namespace HttPlaceholder.Application.Tests.StubExecution.Models;

--- a/src/HttPlaceholder.Application.Tests/StubExecution/ResponseVariableParsingHandlers/DisplayUrlResponseVariableParsingHandlerFacts.cs
+++ b/src/HttPlaceholder.Application.Tests/StubExecution/ResponseVariableParsingHandlers/DisplayUrlResponseVariableParsingHandlerFacts.cs
@@ -21,11 +21,11 @@ public class DisplayUrlResponseVariableParsingHandlerFacts
 
         const string expectedResult = $"URL: {url}";
 
-        var httpContextServiceMock = _mocker.GetMock<IHttpContextService>();
+        var urlResolverMock = _mocker.GetMock<IUrlResolver>();
         var handler = _mocker.CreateInstance<DisplayUrlResponseVariableParsingHandler>();
 
-        httpContextServiceMock
-            .Setup(m => m.DisplayUrl)
+        urlResolverMock
+            .Setup(m => m.GetDisplayUrl())
             .Returns(url);
 
         // act
@@ -45,11 +45,11 @@ public class DisplayUrlResponseVariableParsingHandlerFacts
 
         const string expectedResult = "User ID: 123";
 
-        var httpContextServiceMock = _mocker.GetMock<IHttpContextService>();
+        var urlResolverMock = _mocker.GetMock<IUrlResolver>();
         var handler = _mocker.CreateInstance<DisplayUrlResponseVariableParsingHandler>();
 
-        httpContextServiceMock
-            .Setup(m => m.DisplayUrl)
+        urlResolverMock
+            .Setup(m => m.GetDisplayUrl())
             .Returns(url);
 
         // act
@@ -69,11 +69,11 @@ public class DisplayUrlResponseVariableParsingHandlerFacts
 
         const string expectedResult = "User ID: ";
 
-        var httpContextServiceMock = _mocker.GetMock<IHttpContextService>();
+        var urlResolverMock = _mocker.GetMock<IUrlResolver>();
         var handler = _mocker.CreateInstance<DisplayUrlResponseVariableParsingHandler>();
 
-        httpContextServiceMock
-            .Setup(m => m.DisplayUrl)
+        urlResolverMock
+            .Setup(m => m.GetDisplayUrl())
             .Returns(url);
 
         // act

--- a/src/HttPlaceholder.Application.Tests/StubExecution/ResponseVariableParsingHandlers/RootUrlResponseVariableParsingHandlerFacts.cs
+++ b/src/HttPlaceholder.Application.Tests/StubExecution/ResponseVariableParsingHandlers/RootUrlResponseVariableParsingHandlerFacts.cs
@@ -21,11 +21,11 @@ public class RootUrlResponseVariableParsingHandlerFacts
 
         const string expectedResult = $"URL: {url}";
 
-        var httpContextServiceMock = _mocker.GetMock<IHttpContextService>();
+        var urlResolverMock = _mocker.GetMock<IUrlResolver>();
         var handler = _mocker.CreateInstance<RootUrlResponseVariableParsingHandler>();
 
-        httpContextServiceMock
-            .Setup(m => m.RootUrl)
+        urlResolverMock
+            .Setup(m => m.GetRootUrl())
             .Returns(url);
 
         // act

--- a/src/HttPlaceholder.Application.Tests/StubExecution/ResponseWriters/ReverseProxyResponseWriterFacts.cs
+++ b/src/HttPlaceholder.Application.Tests/StubExecution/ResponseWriters/ReverseProxyResponseWriterFacts.cs
@@ -400,6 +400,7 @@ public class ReverseProxyResponseWriterFacts
         // Arrange
         var writer = _mocker.CreateInstance<ReverseProxyResponseWriter>();
         var mockHttpContextService = _mocker.GetMock<IHttpContextService>();
+        var urlResolverMock = _mocker.GetMock<IUrlResolver>();
         var mockHttpClientFactory = _mocker.GetMock<IHttpClientFactory>();
         var stub = new StubModel
         {
@@ -424,8 +425,8 @@ public class ReverseProxyResponseWriterFacts
         mockHttpContextService
             .Setup(m => m.GetHeaders())
             .Returns(new Dictionary<string, string>());
-        mockHttpContextService
-            .Setup(m => m.RootUrl)
+        urlResolverMock
+            .Setup(m => m.GetRootUrl())
             .Returns("http://localhost:5000");
 
         var mockHttp = new MockHttpMessageHandler();
@@ -460,6 +461,7 @@ public class ReverseProxyResponseWriterFacts
         var writer = _mocker.CreateInstance<ReverseProxyResponseWriter>();
         var mockHttpContextService = _mocker.GetMock<IHttpContextService>();
         var mockHttpClientFactory = _mocker.GetMock<IHttpClientFactory>();
+        var urlResolverMock = _mocker.GetMock<IUrlResolver>();
 
         const string proxyUrl = "https://ducode.org";
         const string path = "/todoitems/todos/1";
@@ -483,8 +485,8 @@ public class ReverseProxyResponseWriterFacts
         mockHttpContextService
             .Setup(m => m.GetHeaders())
             .Returns(new Dictionary<string, string>());
-        mockHttpContextService
-            .Setup(m => m.RootUrl)
+        urlResolverMock
+            .Setup(m => m.GetRootUrl())
             .Returns("http://localhost:5000");
 
         var client = new HttpClient(new ErrorHttpMessageHandler());

--- a/src/HttPlaceholder.Application/Configuration/ConfigKeys.cs
+++ b/src/HttPlaceholder.Application/Configuration/ConfigKeys.cs
@@ -75,6 +75,11 @@ public static class ConfigKeys
     public const string UseHttpsKey = "useHttps";
 
     /// <summary>
+    ///     Constant for publicUrl.
+    /// </summary>
+    public const string PublicUrl = "publicUrl";
+
+    /// <summary>
     ///     Constant for enableRequestLogging.
     /// </summary>
     public const string EnableRequestLoggingKey = "enableRequestLogging";
@@ -256,6 +261,15 @@ public static class ConfigKeys
             "Web:UseHttps",
             ConfigKeyType.Web,
             true,
+            null,
+            null),
+        Create(
+            PublicUrl,
+            "specifies the URL on which this HttPlaceholder instance can be reached. Useful if running behind a reverse proxy.",
+            "https://example.com/stubs",
+            "Web:PublicUrl",
+            ConfigKeyType.Web,
+            null,
             null,
             null),
         Create(

--- a/src/HttPlaceholder.Application/Configuration/ConfigMetadataModel.cs
+++ b/src/HttPlaceholder.Application/Configuration/ConfigMetadataModel.cs
@@ -52,6 +52,9 @@ public class ConfigMetadataModel
     /// </summary>
     public bool? CanBeMutated { get; private set; }
 
+    /// <inheritdoc />
+    public override string ToString() => Key;
+
     /// <summary>
     ///     Creates a new <see cref="ConfigMetadataModel" /> instance
     /// </summary>

--- a/src/HttPlaceholder.Application/Configuration/WebSettingsModel.cs
+++ b/src/HttPlaceholder.Application/Configuration/WebSettingsModel.cs
@@ -21,6 +21,11 @@ public class WebSettingsModel
     public bool UseHttps { get; set; }
 
     /// <summary>
+    ///     Gets or sets the public URL.
+    /// </summary>
+    public string PublicUrl { get; set; }
+
+    /// <summary>
     ///     Gets or sets the path to the HttPlaceholder private key.
     /// </summary>
     public string PfxPath { get; set; }

--- a/src/HttPlaceholder.Application/Extensibility/Notifications/BeforeCheckingStubConditionsNotification.cs
+++ b/src/HttPlaceholder.Application/Extensibility/Notifications/BeforeCheckingStubConditionsNotification.cs
@@ -22,7 +22,8 @@ public class BeforeCheckingStubConditionsNotification : INotification
 
     /// <summary>
     ///     Gets or sets the response that should be returned.
-    ///     Leave this null to continue stub execution, set this if you want to return the response directly without continuing stub execution.
+    ///     Leave this null to continue stub execution, set this if you want to return the response directly without continuing
+    ///     stub execution.
     /// </summary>
     public ResponseModel Response { get; set; }
 }

--- a/src/HttPlaceholder.Application/Extensibility/Notifications/BeforeStubResponseReturnedNotification.cs
+++ b/src/HttPlaceholder.Application/Extensibility/Notifications/BeforeStubResponseReturnedNotification.cs
@@ -4,7 +4,8 @@ using MediatR;
 namespace HttPlaceholder.Application.Extensibility.Notifications;
 
 /// <summary>
-///     This notification is sent just before a stub response is sent back to the client. You have the opportunity to modify the response here.
+///     This notification is sent just before a stub response is sent back to the client. You have the opportunity to
+///     modify the response here.
 ///     This notification is only sent if a valid stub was found.
 /// </summary>
 public class BeforeStubResponseReturnedNotification : INotification

--- a/src/HttPlaceholder.Application/HttPlaceholder.Application.csproj
+++ b/src/HttPlaceholder.Application/HttPlaceholder.Application.csproj
@@ -10,6 +10,7 @@
     <ItemGroup>
         <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1"/>
         <PackageReference Include="Bogus" Version="34.0.2"/>
+        <PackageReference Include="HtmlAgilityPack" Version="1.11.51" />
         <PackageReference Include="IPAddressRange" Version="6.0.0" />
         <PackageReference Include="MediatR" Version="12.1.1" />
         <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="5.0.17"/>

--- a/src/HttPlaceholder.Application/Infrastructure/MediatR/AuditBehavior.cs
+++ b/src/HttPlaceholder.Application/Infrastructure/MediatR/AuditBehavior.cs
@@ -18,12 +18,12 @@ namespace HttPlaceholder.Application.Infrastructure.MediatR;
 public class AuditBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
     where TRequest : IRequest<TResponse>
 {
-    private readonly IOptionsMonitor<SettingsModel> _options;
     private readonly IClientDataResolver _clientDataResolver;
     private readonly ILogger<AuditBehavior<TRequest, TResponse>> _logger;
+    private readonly IOptionsMonitor<SettingsModel> _options;
 
     /// <summary>
-    ///     Constructs an <see cref="AuditBehavior{TRequest, TResponse}"/> instance
+    ///     Constructs an <see cref="AuditBehavior{TRequest, TResponse}" /> instance
     /// </summary>
     public AuditBehavior(
         IOptionsMonitor<SettingsModel> options,

--- a/src/HttPlaceholder.Application/Interfaces/Http/IHtmlService.cs
+++ b/src/HttPlaceholder.Application/Interfaces/Http/IHtmlService.cs
@@ -8,9 +8,9 @@ namespace HttPlaceholder.Application.Interfaces.Http;
 public interface IHtmlService
 {
     /// <summary>
-    ///     Reads an HTML string and converts it to an <see cref="HtmlDocument"/>.
+    ///     Reads an HTML string and converts it to an <see cref="HtmlDocument" />.
     /// </summary>
     /// <param name="html">The HTML string.</param>
-    /// <returns>The converted <see cref="HtmlDocument"/>.</returns>
+    /// <returns>The converted <see cref="HtmlDocument" />.</returns>
     HtmlDocument ReadHtml(string html);
 }

--- a/src/HttPlaceholder.Application/Interfaces/Http/IHtmlService.cs
+++ b/src/HttPlaceholder.Application/Interfaces/Http/IHtmlService.cs
@@ -1,0 +1,16 @@
+﻿using HtmlAgilityPack;
+
+namespace HttPlaceholder.Application.Interfaces.Http;
+
+/// <summary>
+///     Describes a class that is used to work with and manipulate HTML.
+/// </summary>
+public interface IHtmlService
+{
+    /// <summary>
+    ///     Reads an HTML string and converts it to an <see cref="HtmlDocument"/>.
+    /// </summary>
+    /// <param name="html">The HTML string.</param>
+    /// <returns>The converted <see cref="HtmlDocument"/>.</returns>
+    HtmlDocument ReadHtml(string html);
+}

--- a/src/HttPlaceholder.Application/Interfaces/Http/IHttpContextService.cs
+++ b/src/HttPlaceholder.Application/Interfaces/Http/IHttpContextService.cs
@@ -29,16 +29,6 @@ public interface IHttpContextService
     string FullPath { get; }
 
     /// <summary>
-    ///     Gets the current display URL (the full URL + protocol and hostname).
-    /// </summary>
-    string DisplayUrl { get; }
-
-    /// <summary>
-    ///     Gets the current root URL (protocol + hostname).
-    /// </summary>
-    string RootUrl { get; }
-
-    /// <summary>
     ///     Gets the posted body as string.
     /// </summary>
     /// <param name="cancellationToken">The cancellation token.</param>

--- a/src/HttPlaceholder.Application/Interfaces/Http/IUrlResolver.cs
+++ b/src/HttPlaceholder.Application/Interfaces/Http/IUrlResolver.cs
@@ -1,0 +1,19 @@
+﻿namespace HttPlaceholder.Application.Interfaces.Http;
+
+/// <summary>
+///     Describes a class that is used to resolve the HttPlaceholder (root) URLs.
+/// </summary>
+public interface IUrlResolver
+{
+    /// <summary>
+    ///     Gets the current display URL (the full URL + protocol and hostname).
+    /// </summary>
+    /// <returns>The display URL.</returns>
+    string GetDisplayUrl();
+
+    /// <summary>
+    ///     Gets the current root URL (protocol + hostname).
+    /// </summary>
+    /// <returns>The root URL.</returns>
+    string GetRootUrl();
+}

--- a/src/HttPlaceholder.Application/Interfaces/Persistence/IWritableStubSource.cs
+++ b/src/HttPlaceholder.Application/Interfaces/Persistence/IWritableStubSource.cs
@@ -41,7 +41,8 @@ public interface IWritableStubSource : IStubSource
     /// <param name="pagingModel">The paging information.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A list of requests.</returns>
-    Task<IEnumerable<RequestResultModel>> GetRequestResultsAsync(PagingModel pagingModel, CancellationToken cancellationToken);
+    Task<IEnumerable<RequestResultModel>> GetRequestResultsAsync(PagingModel pagingModel,
+        CancellationToken cancellationToken);
 
     /// <summary>
     ///     Gets a list of <see cref="RequestOverviewModel" />.
@@ -49,7 +50,8 @@ public interface IWritableStubSource : IStubSource
     /// <param name="pagingModel">The paging information.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A list of overview requests.</returns>
-    Task<IEnumerable<RequestOverviewModel>> GetRequestResultsOverviewAsync(PagingModel pagingModel, CancellationToken cancellationToken);
+    Task<IEnumerable<RequestOverviewModel>> GetRequestResultsOverviewAsync(PagingModel pagingModel,
+        CancellationToken cancellationToken);
 
     /// <summary>
     ///     Gets a <see cref="RequestResultModel" /> by correlation ID.

--- a/src/HttPlaceholder.Application/Requests/Queries/GetAllRequests/GetAllRequestsQuery.cs
+++ b/src/HttPlaceholder.Application/Requests/Queries/GetAllRequests/GetAllRequestsQuery.cs
@@ -10,7 +10,7 @@ namespace HttPlaceholder.Application.Requests.Queries.GetAllRequests;
 public class GetAllRequestsQuery : IRequest<IEnumerable<RequestResultModel>>
 {
     /// <summary>
-    ///     Constructs a <see cref="GetAllRequestsQuery"/>.
+    ///     Constructs a <see cref="GetAllRequestsQuery" />.
     /// </summary>
     public GetAllRequestsQuery(string fromIdentifier, int? itemsPerPage)
     {

--- a/src/HttPlaceholder.Application/Requests/Queries/GetRequestsOverview/GetRequestsOverviewQuery.cs
+++ b/src/HttPlaceholder.Application/Requests/Queries/GetRequestsOverview/GetRequestsOverviewQuery.cs
@@ -10,7 +10,7 @@ namespace HttPlaceholder.Application.Requests.Queries.GetRequestsOverview;
 public class GetRequestsOverviewQuery : IRequest<IEnumerable<RequestOverviewModel>>
 {
     /// <summary>
-    ///     Constructs a <see cref="GetRequestsOverviewQuery"/>.
+    ///     Constructs a <see cref="GetRequestsOverviewQuery" />.
     /// </summary>
     public GetRequestsOverviewQuery(string fromIdentifier, int? itemsPerPage)
     {

--- a/src/HttPlaceholder.Application/ScheduledJobs/Commands/ExecuteScheduledJob/ExecuteScheduledJobCommand.cs
+++ b/src/HttPlaceholder.Application/ScheduledJobs/Commands/ExecuteScheduledJob/ExecuteScheduledJobCommand.cs
@@ -9,7 +9,7 @@ namespace HttPlaceholder.Application.ScheduledJobs.Commands.ExecuteScheduledJob;
 public class ExecuteScheduledJobCommand : IRequest<JobExecutionResultModel>
 {
     /// <summary>
-    ///     Constructs an <see cref="ExecuteScheduledJobCommand"/> instance.
+    ///     Constructs an <see cref="ExecuteScheduledJobCommand" /> instance.
     /// </summary>
     /// <param name="jobName"></param>
     public ExecuteScheduledJobCommand(string jobName)

--- a/src/HttPlaceholder.Application/ScheduledJobs/Commands/ExecuteScheduledJob/ExecuteScheduledJobCommandHandler.cs
+++ b/src/HttPlaceholder.Application/ScheduledJobs/Commands/ExecuteScheduledJob/ExecuteScheduledJobCommandHandler.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using HttPlaceholder.Application.Exceptions;
@@ -19,7 +18,7 @@ public class ExecuteScheduledJobCommandHandler : IRequestHandler<ExecuteSchedule
     private readonly IEnumerable<ICustomHostedService> _hostedServices;
 
     /// <summary>
-    ///     Constructs an <see cref="ExecuteScheduledJobCommandHandler"/> instance.
+    ///     Constructs an <see cref="ExecuteScheduledJobCommandHandler" /> instance.
     /// </summary>
     public ExecuteScheduledJobCommandHandler(IEnumerable<ICustomHostedService> hostedServices)
     {
@@ -27,7 +26,8 @@ public class ExecuteScheduledJobCommandHandler : IRequestHandler<ExecuteSchedule
     }
 
     /// <inheritdoc />
-    public async Task<JobExecutionResultModel> Handle(ExecuteScheduledJobCommand request, CancellationToken cancellationToken)
+    public async Task<JobExecutionResultModel> Handle(ExecuteScheduledJobCommand request,
+        CancellationToken cancellationToken)
     {
         var message = "OK";
         var job = _hostedServices.FirstOrDefault(s =>

--- a/src/HttPlaceholder.Application/ScheduledJobs/Queries/GetScheduledJobNames/GetScheduledJobNamesQueryHandler.cs
+++ b/src/HttPlaceholder.Application/ScheduledJobs/Queries/GetScheduledJobNames/GetScheduledJobNamesQueryHandler.cs
@@ -14,7 +14,7 @@ public class GetScheduledJobNamesQueryHandler : IRequestHandler<GetScheduledJobN
     private readonly IEnumerable<ICustomHostedService> _hostedServices;
 
     /// <summary>
-    ///     Constructs an <see cref="GetScheduledJobNamesQueryHandler"/> instance.
+    ///     Constructs an <see cref="GetScheduledJobNamesQueryHandler" /> instance.
     /// </summary>
     public GetScheduledJobNamesQueryHandler(IEnumerable<ICustomHostedService> hostedServices)
     {

--- a/src/HttPlaceholder.Application/StubExecution/Commands/HandleStubRequestCommandHandler.cs
+++ b/src/HttPlaceholder.Application/StubExecution/Commands/HandleStubRequestCommandHandler.cs
@@ -13,7 +13,7 @@ public class HandleStubRequestCommandHandler : IRequestHandler<HandleStubRequest
     private readonly IStubRequestExecutor _stubRequestExecutor;
 
     /// <summary>
-    ///     Constructs a <see cref="HandleStubRequestCommandHandler"/> instance.
+    ///     Constructs a <see cref="HandleStubRequestCommandHandler" /> instance.
     /// </summary>
     /// <param name="stubRequestExecutor"></param>
     public HandleStubRequestCommandHandler(IStubRequestExecutor stubRequestExecutor)

--- a/src/HttPlaceholder.Application/StubExecution/Implementations/RequestStubGenerator.cs
+++ b/src/HttPlaceholder.Application/StubExecution/Implementations/RequestStubGenerator.cs
@@ -14,10 +14,10 @@ namespace HttPlaceholder.Application.StubExecution.Implementations;
 internal class RequestStubGenerator : IRequestStubGenerator, ISingletonService
 {
     private readonly IHttpRequestToConditionsService _httpRequestToConditionsService;
+    private readonly IHttpResponseToStubResponseService _httpResponseToStubResponseService;
     private readonly ILogger<RequestStubGenerator> _logger;
     private readonly IMapper _mapper;
     private readonly IStubContext _stubContext;
-    private readonly IHttpResponseToStubResponseService _httpResponseToStubResponseService;
 
     public RequestStubGenerator(
         IStubContext stubContext,

--- a/src/HttPlaceholder.Application/StubExecution/Implementations/StubRequestExecutor.cs
+++ b/src/HttPlaceholder.Application/StubExecution/Implementations/StubRequestExecutor.cs
@@ -19,11 +19,11 @@ internal class StubRequestExecutor : IStubRequestExecutor, ISingletonService
     private readonly IEnumerable<IConditionChecker> _conditionCheckers;
     private readonly IFinalStubDeterminer _finalStubDeterminer;
     private readonly ILogger<StubRequestExecutor> _logger;
+    private readonly IMediator _mediator;
     private readonly IRequestLoggerFactory _requestLoggerFactory;
     private readonly IScenarioService _scenarioService;
     private readonly IStubContext _stubContext;
     private readonly IStubResponseGenerator _stubResponseGenerator;
-    private readonly IMediator _mediator;
 
     public StubRequestExecutor(
         IEnumerable<IConditionChecker> conditionCheckers,

--- a/src/HttPlaceholder.Application/StubExecution/Models/HttpResponseModel.cs
+++ b/src/HttPlaceholder.Application/StubExecution/Models/HttpResponseModel.cs
@@ -9,7 +9,8 @@ namespace HttPlaceholder.Application.StubExecution.Models;
 
 /// <summary>
 ///     A model that contains a representation of an HTTP response.
-///     This model is mainly used in converting one data source (e.g. a HTTP Archive, or HAR) to an intermediate data source
+///     This model is mainly used in converting one data source (e.g. a HTTP Archive, or HAR) to an intermediate data
+///     source
 ///     that can be used to generate a response for use in a stub.
 /// </summary>
 public class HttpResponseModel : IHaveCustomMapping

--- a/src/HttPlaceholder.Application/StubExecution/ResponseVariableParsingHandlers/DisplayUrlResponseVariableParsingHandler.cs
+++ b/src/HttPlaceholder.Application/StubExecution/ResponseVariableParsingHandlers/DisplayUrlResponseVariableParsingHandler.cs
@@ -16,15 +16,18 @@ namespace HttPlaceholder.Application.StubExecution.ResponseVariableParsingHandle
 /// </summary>
 internal class DisplayUrlResponseVariableParsingHandler : BaseVariableParsingHandler, ISingletonService
 {
-    private readonly IHttpContextService _httpContextService;
+    private readonly IUrlResolver _urlResolver;
     private readonly ILogger<DisplayUrlResponseVariableParsingHandler> _logger;
 
-    public DisplayUrlResponseVariableParsingHandler(IHttpContextService httpContextService, IFileService fileService,
-        ILogger<DisplayUrlResponseVariableParsingHandler> logger) :
+
+    public DisplayUrlResponseVariableParsingHandler(
+        IFileService fileService,
+        ILogger<DisplayUrlResponseVariableParsingHandler> logger,
+        IUrlResolver urlResolver) :
         base(fileService)
     {
-        _httpContextService = httpContextService;
         _logger = logger;
+        _urlResolver = urlResolver;
     }
 
     /// <inheritdoc />
@@ -41,7 +44,7 @@ internal class DisplayUrlResponseVariableParsingHandler : BaseVariableParsingHan
         CancellationToken cancellationToken) =>
         Task.FromResult(matches
             .Where(match => match.Groups.Count >= 2)
-            .Aggregate(input, (current, match) => HandleDisplayUrl(match, current, _httpContextService.DisplayUrl)));
+            .Aggregate(input, (current, match) => HandleDisplayUrl(match, current, _urlResolver.GetDisplayUrl())));
 
     private string HandleDisplayUrl(Match match, string current, string url)
     {

--- a/src/HttPlaceholder.Application/StubExecution/ResponseVariableParsingHandlers/DisplayUrlResponseVariableParsingHandler.cs
+++ b/src/HttPlaceholder.Application/StubExecution/ResponseVariableParsingHandlers/DisplayUrlResponseVariableParsingHandler.cs
@@ -16,8 +16,8 @@ namespace HttPlaceholder.Application.StubExecution.ResponseVariableParsingHandle
 /// </summary>
 internal class DisplayUrlResponseVariableParsingHandler : BaseVariableParsingHandler, ISingletonService
 {
-    private readonly IUrlResolver _urlResolver;
     private readonly ILogger<DisplayUrlResponseVariableParsingHandler> _logger;
+    private readonly IUrlResolver _urlResolver;
 
 
     public DisplayUrlResponseVariableParsingHandler(

--- a/src/HttPlaceholder.Application/StubExecution/ResponseVariableParsingHandlers/RootUrlResponseVariableParsingHandler.cs
+++ b/src/HttPlaceholder.Application/StubExecution/ResponseVariableParsingHandlers/RootUrlResponseVariableParsingHandler.cs
@@ -15,12 +15,14 @@ namespace HttPlaceholder.Application.StubExecution.ResponseVariableParsingHandle
 /// </summary>
 internal class RootUrlResponseVariableParsingHandler : BaseVariableParsingHandler, ISingletonService
 {
-    private readonly IHttpContextService _httpContextService;
+    private readonly IUrlResolver _urlResolver;
 
-    public RootUrlResponseVariableParsingHandler(IHttpContextService httpContextService, IFileService fileService) :
+    public RootUrlResponseVariableParsingHandler(
+        IFileService fileService,
+        IUrlResolver urlResolver) :
         base(fileService)
     {
-        _httpContextService = httpContextService;
+        _urlResolver = urlResolver;
     }
 
     /// <inheritdoc />
@@ -35,7 +37,7 @@ internal class RootUrlResponseVariableParsingHandler : BaseVariableParsingHandle
     protected override Task<string> InsertVariablesAsync(string input, Match[] matches, StubModel stub,
         CancellationToken cancellationToken)
     {
-        var url = _httpContextService.RootUrl;
+        var url = _urlResolver.GetRootUrl();
         return Task.FromResult(matches
             .Where(match => match.Groups.Count >= 2)
             .Aggregate(input, (current, match) => current.Replace(match.Value, url)));

--- a/src/HttPlaceholder.Application/StubExecution/ResponseVariableParsingHandlers/ScenarioHitCountVariableParsingHandler.cs
+++ b/src/HttPlaceholder.Application/StubExecution/ResponseVariableParsingHandlers/ScenarioHitCountVariableParsingHandler.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using System.Linq;
+﻿using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,8 +16,8 @@ namespace HttPlaceholder.Application.StubExecution.ResponseVariableParsingHandle
 /// </summary>
 internal class ScenarioHitCountVariableParsingHandler : BaseVariableParsingHandler, ISingletonService
 {
-    private readonly IScenarioStateStore _scenarioStateStore;
     private readonly IHttpContextService _httpContextService;
+    private readonly IScenarioStateStore _scenarioStateStore;
 
     public ScenarioHitCountVariableParsingHandler(
         IScenarioStateStore scenarioStateStore,

--- a/src/HttPlaceholder.Application/StubExecution/ResponseVariableParsingHandlers/ScenarioStateVariableParsingHandler.cs
+++ b/src/HttPlaceholder.Application/StubExecution/ResponseVariableParsingHandlers/ScenarioStateVariableParsingHandler.cs
@@ -15,8 +15,8 @@ namespace HttPlaceholder.Application.StubExecution.ResponseVariableParsingHandle
 /// </summary>
 internal class ScenarioStateVariableParsingHandler : BaseVariableParsingHandler, ISingletonService
 {
-    private readonly IScenarioStateStore _scenarioStateStore;
     private readonly IHttpContextService _httpContextService;
+    private readonly IScenarioStateStore _scenarioStateStore;
 
     public ScenarioStateVariableParsingHandler(
         IScenarioStateStore scenarioStateStore,

--- a/src/HttPlaceholder.Application/StubExecution/ResponseWriters/FileResponseWriter.cs
+++ b/src/HttPlaceholder.Application/StubExecution/ResponseWriters/FileResponseWriter.cs
@@ -20,9 +20,9 @@ internal class FileResponseWriter : IResponseWriter, ISingletonService
 {
     private readonly IFileService _fileService;
     private readonly ILogger<FileResponseWriter> _logger;
+    private readonly IMimeService _mimeService;
     private readonly IOptionsMonitor<SettingsModel> _options;
     private readonly IStubRootPathResolver _stubRootPathResolver;
-    private readonly IMimeService _mimeService;
 
     public FileResponseWriter(
         IFileService fileService,

--- a/src/HttPlaceholder.Application/StubExecution/ResponseWriters/ReverseProxyResponseWriter.cs
+++ b/src/HttPlaceholder.Application/StubExecution/ResponseWriters/ReverseProxyResponseWriter.cs
@@ -35,15 +35,18 @@ internal class ReverseProxyResponseWriter : IResponseWriter, ISingletonService
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IHttpContextService _httpContextService;
     private readonly ILogger<ReverseProxyResponseWriter> _logger;
+    private readonly IUrlResolver _urlResolver;
 
     public ReverseProxyResponseWriter(
         IHttpClientFactory httpClientFactory,
         IHttpContextService httpContextService,
-        ILogger<ReverseProxyResponseWriter> logger)
+        ILogger<ReverseProxyResponseWriter> logger,
+        IUrlResolver urlResolver)
     {
         _httpClientFactory = httpClientFactory;
         _httpContextService = httpContextService;
         _logger = logger;
+        _urlResolver = urlResolver;
     }
 
     /// <inheritdoc />
@@ -147,7 +150,7 @@ internal class ReverseProxyResponseWriter : IResponseWriter, ISingletonService
     {
         var rootUrlParts = proxyUrl.Split(new[] {"/"}, StringSplitOptions.RemoveEmptyEntries);
         var rootUrl = $"{rootUrlParts[0]}//{rootUrlParts[1]}";
-        var httPlaceholderRootUrl = _httpContextService.RootUrl;
+        var httPlaceholderRootUrl = _urlResolver.GetRootUrl();
         var path = GetPath(stub);
         if (appendPath && !string.IsNullOrWhiteSpace(path))
         {

--- a/src/HttPlaceholder.Client.Tests/HttPlaceholderClientFacts/CreateStubsFacts.cs
+++ b/src/HttPlaceholder.Client.Tests/HttPlaceholderClientFacts/CreateStubsFacts.cs
@@ -95,14 +95,16 @@ public class CreateStubsFacts : BaseClientTest
             {
                 Id = "test-situation1",
                 Tenant = "01-get",
-                Conditions = new StubConditionsDto
-                {
-                    Method = "GET",
-                    Url = new StubUrlConditionDto
+                Conditions =
+                    new StubConditionsDto
                     {
-                        Path = "/testtesttest", Query = new Dictionary<string, object> {{"id", "13"}}
-                    }
-                },
+                        Method = "GET",
+                        Url = new StubUrlConditionDto
+                        {
+                            Path = "/testtesttest",
+                            Query = new Dictionary<string, object> {{"id", "13"}}
+                        }
+                    },
                 Response = new StubResponseDto {StatusCode = 200, Text = "OK my dude!"}
             },
             new StubDto

--- a/src/HttPlaceholder.Client/IHttPlaceholderClient.cs
+++ b/src/HttPlaceholder.Client/IHttPlaceholderClient.cs
@@ -46,11 +46,15 @@ public interface IHttPlaceholderClient
     /// <summary>
     ///     Retrieves all requests made to HttPlaceholder.
     /// </summary>
-    /// <param name="fromIdentifier">The correlation ID from which the requests will be skipped. All requests before this request are not taken into account.</param>
+    /// <param name="fromIdentifier">
+    ///     The correlation ID from which the requests will be skipped. All requests before this
+    ///     request are not taken into account.
+    /// </param>
     /// <param name="numberOfRequestsPerPage">The number of requests to return.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The requests.</returns>
-    Task<IEnumerable<RequestResultDto>> GetAllRequestsAsync(string fromIdentifier, int numberOfRequestsPerPage, CancellationToken cancellationToken = default);
+    Task<IEnumerable<RequestResultDto>> GetAllRequestsAsync(string fromIdentifier, int numberOfRequestsPerPage,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Retrieves all requests made to HttPlaceholder as overview.
@@ -62,11 +66,15 @@ public interface IHttPlaceholderClient
     /// <summary>
     ///     Retrieves all requests made to HttPlaceholder as overview.
     /// </summary>
-    /// <param name="fromIdentifier">The correlation ID from which the requests will be skipped. All requests before this request are not taken into account.</param>
+    /// <param name="fromIdentifier">
+    ///     The correlation ID from which the requests will be skipped. All requests before this
+    ///     request are not taken into account.
+    /// </param>
     /// <param name="numberOfRequestsPerPage">The number of requests to return.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The request overview.</returns>
-    Task<IEnumerable<RequestOverviewDto>> GetRequestOverviewAsync(string fromIdentifier, int numberOfRequestsPerPage, CancellationToken cancellationToken = default);
+    Task<IEnumerable<RequestOverviewDto>> GetRequestOverviewAsync(string fromIdentifier, int numberOfRequestsPerPage,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Retrieves a request by correlation ID.

--- a/src/HttPlaceholder.Common.Tests/Utilities/StringHelperFacts.cs
+++ b/src/HttPlaceholder.Common.Tests/Utilities/StringHelperFacts.cs
@@ -6,6 +6,13 @@ namespace HttPlaceholder.Common.Tests.Utilities;
 [TestClass]
 public class StringHelperFacts
 {
+    public static IEnumerable<object> GetFirstNonWhitespaceString_TestData =>
+        new[]
+        {
+            new object[] {new[] {"1", "2", "3"}, "1"}, new object[] {new[] {"", "2", "3"}, "2"},
+            new object[] {new[] {"", null, "3"}, "3"}, new object[] {new[] {"", null, null}, null}
+        };
+
     [TestMethod]
     public void IsRegexMatchOrSubstring_IsNotAMatch_ShouldReturnFalse()
     {
@@ -108,15 +115,6 @@ public class StringHelperFacts
         Assert.AreEqual("this", result[1]);
         Assert.AreEqual("text", result[2]);
     }
-
-    public static IEnumerable<object> GetFirstNonWhitespaceString_TestData =>
-        new[]
-        {
-            new object[] {new[] {"1", "2", "3"}, "1"},
-            new object[] {new[] {"", "2", "3"}, "2"},
-            new object[] {new[] {"", null, "3"}, "3"},
-            new object[] {new[] {"", null, null}, null},
-        };
 
     [TestMethod]
     [DynamicData(nameof(GetFirstNonWhitespaceString_TestData))]

--- a/src/HttPlaceholder.Common.Tests/Utilities/StringHelperFacts.cs
+++ b/src/HttPlaceholder.Common.Tests/Utilities/StringHelperFacts.cs
@@ -47,6 +47,20 @@ public class StringHelperFacts
     }
 
     [DataTestMethod]
+    [DataRow("input-", '-', "input")]
+    [DataRow("input", '-', "input")]
+    [DataRow("--input-", '-', "--input")]
+    [DataRow("--input----", '-', "--input")]
+    public void EnsureDoesntEndWith_HappyFlow(string input, char character, string expectedResult)
+    {
+        // Act
+        var result = input.EnsureDoesntEndWith(character);
+
+        // Assert
+        Assert.AreEqual(expectedResult, result);
+    }
+
+    [DataTestMethod]
     [DataRow("-input", "-", "-input")]
     [DataRow("input", "-", "-input")]
     public void EnsureStartsWith_HappyFlow(string input, string append, string expectedResult)

--- a/src/HttPlaceholder.Common/Utilities/StringHelper.cs
+++ b/src/HttPlaceholder.Common/Utilities/StringHelper.cs
@@ -44,6 +44,14 @@ public static class StringHelper
     }
 
     /// <summary>
+    ///     Ensures that a string doesn't end with a given string.
+    /// </summary>
+    /// <param name="input">The input string.</param>
+    /// <param name="character">The character the input should not end with.</param>
+    /// <returns>The converted input.</returns>
+    public static string EnsureDoesntEndWith(this string input, char character) => input.TrimEnd(character);
+
+    /// <summary>
     ///     Ensures that a string starts with a given string.
     /// </summary>
     /// <param name="input">The input string.</param>

--- a/src/HttPlaceholder.Persistence.Tests/Implementations/ScenarioStateStoreFacts.cs
+++ b/src/HttPlaceholder.Persistence.Tests/Implementations/ScenarioStateStoreFacts.cs
@@ -157,7 +157,8 @@ public class ScenarioStateStoreFacts
         var scenarioInStore = store.Scenarios.Values.Single();
         _mocker.GetMock<IHttpContextService>()
             .Verify(m => m.SetItem(CachingKeys.ScenarioState, It.Is<ScenarioStateModel>(
-                _ => _.HitCount == newScenario.HitCount && _.State == newScenario.State && _.Scenario == scenarioName)));
+                _ => _.HitCount == newScenario.HitCount && _.State == newScenario.State &&
+                     _.Scenario == scenarioName)));
         Assert.AreNotEqual(newScenario, scenarioInStore);
         AssertScenarioStatesAreEqual(scenarioInStore, newScenario);
     }

--- a/src/HttPlaceholder.Persistence.Tests/Implementations/StubSources/FileSystemStubSourceFacts.cs
+++ b/src/HttPlaceholder.Persistence.Tests/Implementations/StubSources/FileSystemStubSourceFacts.cs
@@ -472,10 +472,9 @@ public class FileSystemStubSourceFacts
             .ReturnsAsync(JsonConvert.SerializeObject(new RequestResultModel {CorrelationId = "request-02"}));
 
         // Act
-        var result = (await source.GetRequestResultsAsync(new PagingModel
-        {
-            FromIdentifier = "request-01"
-        }, CancellationToken.None)).ToArray();
+        var result =
+            (await source.GetRequestResultsAsync(new PagingModel {FromIdentifier = "request-01"},
+                CancellationToken.None)).ToArray();
 
         // Assert
         Assert.AreEqual(1, result.Length);
@@ -489,8 +488,7 @@ public class FileSystemStubSourceFacts
         var requestsFolder = Path.Combine(StorageFolder, FileNames.RequestsFolderName);
         var files = new[]
         {
-            Path.Combine(requestsFolder, "request-01.json"),
-            Path.Combine(requestsFolder, "request-02.json"),
+            Path.Combine(requestsFolder, "request-01.json"), Path.Combine(requestsFolder, "request-02.json"),
             Path.Combine(requestsFolder, "request-03.json")
         };
 
@@ -518,11 +516,9 @@ public class FileSystemStubSourceFacts
         }
 
         // Act
-        var result = (await source.GetRequestResultsAsync(new PagingModel
-        {
-            FromIdentifier = "request-02",
-            ItemsPerPage = 2
-        }, CancellationToken.None)).ToArray();
+        var result =
+            (await source.GetRequestResultsAsync(new PagingModel {FromIdentifier = "request-02", ItemsPerPage = 2},
+                CancellationToken.None)).ToArray();
 
         // Assert
         Assert.AreEqual(2, result.Length);

--- a/src/HttPlaceholder.Persistence.Tests/Implementations/StubSources/InMemoryStubSourceFacts.cs
+++ b/src/HttPlaceholder.Persistence.Tests/Implementations/StubSources/InMemoryStubSourceFacts.cs
@@ -276,10 +276,8 @@ public class InMemoryStubSourceFacts
         source.RequestResultModels.Add(request3);
 
         // Act
-        var result = (await source.GetRequestResultsAsync(new PagingModel
-        {
-            FromIdentifier = request2.CorrelationId
-        }, CancellationToken.None)).ToArray();
+        var result = (await source.GetRequestResultsAsync(new PagingModel {FromIdentifier = request2.CorrelationId},
+            CancellationToken.None)).ToArray();
 
         // Assert
         Assert.AreEqual(2, result.Length);
@@ -302,11 +300,10 @@ public class InMemoryStubSourceFacts
         source.RequestResultModels.Add(request4);
 
         // Act
-        var result = (await source.GetRequestResultsAsync(new PagingModel
-        {
-            FromIdentifier = request3.CorrelationId,
-            ItemsPerPage = 2
-        }, CancellationToken.None)).ToArray();
+        var result =
+            (await source.GetRequestResultsAsync(
+                new PagingModel {FromIdentifier = request3.CorrelationId, ItemsPerPage = 2}, CancellationToken.None))
+            .ToArray();
 
         // Assert
         Assert.AreEqual(2, result.Length);

--- a/src/HttPlaceholder.Persistence.Tests/Implementations/StubSources/RelationalDbStubSourceFacts.cs
+++ b/src/HttPlaceholder.Persistence.Tests/Implementations/StubSources/RelationalDbStubSourceFacts.cs
@@ -548,7 +548,11 @@ public class RelationalDbStubSourceFacts
 
         var stubSource = _mocker.CreateInstance<RelationalDbStubSource>();
 
-        var ids = new[] {Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString()};
+        var ids = new[]
+        {
+            Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(),
+            Guid.NewGuid().ToString()
+        };
         _mockDatabaseContext
             .Setup(m => m.QueryAsync<string>(correlationIdsQuery, It.IsAny<CancellationToken>(), null))
             .ReturnsAsync(ids);
@@ -583,7 +587,8 @@ public class RelationalDbStubSourceFacts
 
         // Act
         var result =
-            (await stubSource.GetRequestResultsAsync(new PagingModel {FromIdentifier = ids[1], ItemsPerPage = 2}, CancellationToken.None))
+            (await stubSource.GetRequestResultsAsync(new PagingModel {FromIdentifier = ids[1], ItemsPerPage = 2},
+                CancellationToken.None))
             .ToArray();
 
         // Assert

--- a/src/HttPlaceholder.Persistence/Db/Implementations/SqliteQueryStore.cs
+++ b/src/HttPlaceholder.Persistence/Db/Implementations/SqliteQueryStore.cs
@@ -31,7 +31,8 @@ WHERE correlation_id IN @CorrelationIds
 ORDER BY request_begin_time DESC";
 
     /// <inheritdoc />
-    public string GetPagedRequestCorrelationIdsQuery => "SELECT correlation_id FROM requests ORDER BY request_begin_time DESC";
+    public string GetPagedRequestCorrelationIdsQuery =>
+        "SELECT correlation_id FROM requests ORDER BY request_begin_time DESC";
 
     /// <inheritdoc />
     public string GetRequestQuery => @"SELECT

--- a/src/HttPlaceholder.Persistence/Implementations/StubSources/BaseWritableStubSource.cs
+++ b/src/HttPlaceholder.Persistence/Implementations/StubSources/BaseWritableStubSource.cs
@@ -36,7 +36,8 @@ public abstract class BaseWritableStubSource : IWritableStubSource
         CancellationToken cancellationToken);
 
     /// <inheritdoc />
-    public abstract Task<IEnumerable<RequestResultModel>> GetRequestResultsAsync(PagingModel pagingModel, CancellationToken cancellationToken);
+    public abstract Task<IEnumerable<RequestResultModel>> GetRequestResultsAsync(PagingModel pagingModel,
+        CancellationToken cancellationToken);
 
     /// <inheritdoc />
     public abstract Task<RequestResultModel> GetRequestAsync(string correlationId, CancellationToken cancellationToken);

--- a/src/HttPlaceholder.Persistence/Implementations/StubSources/FileSystemStubSource.cs
+++ b/src/HttPlaceholder.Persistence/Implementations/StubSources/FileSystemStubSource.cs
@@ -19,10 +19,10 @@ namespace HttPlaceholder.Persistence.Implementations.StubSources;
 /// </summary>
 internal class FileSystemStubSource : BaseWritableStubSource
 {
+    private readonly IDateTime _dateTime;
     private readonly IFileService _fileService;
     private readonly IFileSystemStubCache _fileSystemStubCache;
     private readonly IOptionsMonitor<SettingsModel> _options;
-    private readonly IDateTime _dateTime;
 
     public FileSystemStubSource(
         IFileService fileService,

--- a/src/HttPlaceholder.Tests/Integration/GenericIntegrationTests.cs
+++ b/src/HttPlaceholder.Tests/Integration/GenericIntegrationTests.cs
@@ -108,7 +108,7 @@ public class GenericIntegrationTests : IntegrationTestBase
     }
 
     [TestMethod]
-    public async Task GenericIntegration_Ui_Returns404()
+    public async Task GenericIntegration_Ui_ReturnsModifiedHtml()
     {
         // The URL ph-ui is not executed as stub, so it doesn't return an HTTP 500 when called.
 
@@ -117,8 +117,13 @@ public class GenericIntegrationTests : IntegrationTestBase
 
         var request = new HttpRequestMessage {Method = HttpMethod.Get, RequestUri = new Uri(url)};
 
-        // Act / Assert
+        // Act
         using var response = await Client.SendAsync(request);
-        Assert.AreNotEqual(HttpStatusCode.InternalServerError, response.StatusCode);
+
+        // Assert
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+
+        var content = await response.Content.ReadAsStringAsync();
+        Assert.IsTrue(content.Contains("""<base href="http://localhost"><script type="text/javascript">window.rootUrl = "http://localhost";</script>"""));
     }
 }

--- a/src/HttPlaceholder.Tests/Integration/GenericIntegrationTests.cs
+++ b/src/HttPlaceholder.Tests/Integration/GenericIntegrationTests.cs
@@ -124,6 +124,7 @@ public class GenericIntegrationTests : IntegrationTestBase
         Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
 
         var content = await response.Content.ReadAsStringAsync();
-        Assert.IsTrue(content.Contains("""<base href="http://localhost"><script type="text/javascript">window.rootUrl = "http://localhost";</script>"""));
+        Assert.IsTrue(content.Contains(
+            """<base href="http://localhost"><script type="text/javascript">window.rootUrl = "http://localhost";</script>"""));
     }
 }

--- a/src/HttPlaceholder.Tests/Integration/IntegrationTestBase.cs
+++ b/src/HttPlaceholder.Tests/Integration/IntegrationTestBase.cs
@@ -31,7 +31,9 @@ public abstract class IntegrationTestBase
         var config = new ConfigurationBuilder()
             .AddCustomInMemoryCollection(new Dictionary<string, string>
             {
-                {"Storage:InputFile", @"C:\tmp"}, {"Storage:CleanOldRequestsInBackgroundJob", "true"}
+                {"Storage:InputFile", @"C:\tmp"},
+                {"Storage:CleanOldRequestsInBackgroundJob", "true"},
+                {"Gui:EnableUserInterface", "true"}
             })
             .Build();
         servicesToReplace = servicesToReplace.Concat(new (Type, object)[]

--- a/src/HttPlaceholder.Tests/Integration/RestApi/RestApiConfigurationTests.cs
+++ b/src/HttPlaceholder.Tests/Integration/RestApi/RestApiConfigurationTests.cs
@@ -30,7 +30,7 @@ public class RestApiConfigurationTests : RestApiIntegrationTestBase
         var content = await response.Content.ReadAsStringAsync();
         var config = JsonConvert.DeserializeObject<IEnumerable<ConfigurationDto>>(content);
         Assert.IsNotNull(config);
-        Assert.AreEqual(2, config.Count());
+        Assert.AreEqual(3, config.Count());
     }
 
     [TestMethod]
@@ -55,7 +55,7 @@ public class RestApiConfigurationTests : RestApiIntegrationTestBase
         var content = await getConfigResponse.Content.ReadAsStringAsync();
         var config = JsonConvert.DeserializeObject<ConfigurationDto[]>(content);
         Assert.IsNotNull(config);
-        Assert.AreEqual(3, config.Length);
+        Assert.AreEqual(4, config.Length);
         var storeResponsesConfig = config.Single(c => c.Key == "storeResponses");
         Assert.AreEqual("true", storeResponsesConfig.Value);
     }

--- a/src/HttPlaceholder.Tests/Integration/RestApi/RestApiRequestIntegrationTests.cs
+++ b/src/HttPlaceholder.Tests/Integration/RestApi/RestApiRequestIntegrationTests.cs
@@ -41,8 +41,7 @@ public class RestApiRequestIntegrationTests : RestApiIntegrationTestBase
         {
             StubSource.RequestResultModels.Add(new RequestResultModel
             {
-                CorrelationId = Guid.NewGuid().ToString(),
-                RequestEndTime = DateTime.Now
+                CorrelationId = Guid.NewGuid().ToString(), RequestEndTime = DateTime.Now
             });
         }
 
@@ -165,8 +164,7 @@ public class RestApiRequestIntegrationTests : RestApiIntegrationTestBase
         {
             StubSource.RequestResultModels.Add(new RequestResultModel
             {
-                CorrelationId = Guid.NewGuid().ToString(),
-                RequestEndTime = DateTime.Now
+                CorrelationId = Guid.NewGuid().ToString(), RequestEndTime = DateTime.Now
             });
         }
 

--- a/src/HttPlaceholder.Tests/Integration/RestApi/RestApiStubGenerationTests.cs
+++ b/src/HttPlaceholder.Tests/Integration/RestApi/RestApiStubGenerationTests.cs
@@ -126,7 +126,10 @@ public class RestApiStubGenerationTests : RestApiIntegrationTestBase
         {
             CorrelationId = correlationId,
             RequestParameters =
-                new RequestParametersModel {Url = "/the-url", Headers = new Dictionary<string, string>(), Method = "GET"},
+                new RequestParametersModel
+                {
+                    Url = "/the-url", Headers = new Dictionary<string, string>(), Method = "GET"
+                },
             HasResponse = true,
             ExecutingStubId = "x"
         };
@@ -149,7 +152,8 @@ public class RestApiStubGenerationTests : RestApiIntegrationTestBase
 
         // Check the response.
         var stub = JsonConvert.DeserializeObject<FullStubModel>(content);
-        Assert.AreEqual("/the-url", ((JObject)stub.Stub.Conditions.Url.Path).ToObject<StubConditionStringCheckingModel>().StringEquals);
+        Assert.AreEqual("/the-url",
+            ((JObject)stub.Stub.Conditions.Url.Path).ToObject<StubConditionStringCheckingModel>().StringEquals);
         Assert.AreEqual("the content", stub.Stub.Response.Text);
     }
 

--- a/src/HttPlaceholder.Tests/Integration/Stubs/StubFileIntegrationTests.cs
+++ b/src/HttPlaceholder.Tests/Integration/Stubs/StubFileIntegrationTests.cs
@@ -34,7 +34,8 @@ public class StubFileIntegrationTests : StubIntegrationTestBase
         var content = await response.Content.ReadAsStringAsync();
         Assert.AreEqual(fileContents, content);
         Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
-        Assert.AreEqual("application/octet-stream", response.Content.Headers.Single(h => h.Key == "Content-Type").Value.Single());
+        Assert.AreEqual("application/octet-stream",
+            response.Content.Headers.Single(h => h.Key == "Content-Type").Value.Single());
     }
 
     [TestMethod]

--- a/src/HttPlaceholder.Web.Shared.Tests/Middleware/IndexHtmlMiddlewareFacts.cs
+++ b/src/HttPlaceholder.Web.Shared.Tests/Middleware/IndexHtmlMiddlewareFacts.cs
@@ -24,8 +24,8 @@ public class IndexHtmlMiddlewareFacts
         _mocker.Use(UiPath);
     }
 
-    // [TestCleanup]
-    // public void Cleanup() => _mocker.VerifyAll();
+    [TestCleanup]
+    public void Cleanup() => _mocker.VerifyAll();
 
     [TestMethod]
     public async Task Invoke_PathNotForUi_ShouldContinue()
@@ -106,6 +106,7 @@ public class IndexHtmlMiddlewareFacts
         var urlResolverMock = _mocker.GetMock<IUrlResolver>();
         var htmlServiceMock = _mocker.GetMock<IHtmlService>();
         var middleware = _mocker.CreateInstance<IndexHtmlMiddleware>();
+        IndexHtmlMiddleware.IndexHtml = null;
 
         httpContextServiceMock
             .Setup(m => m.Path)

--- a/src/HttPlaceholder.Web.Shared.Tests/Middleware/IndexHtmlMiddlewareFacts.cs
+++ b/src/HttPlaceholder.Web.Shared.Tests/Middleware/IndexHtmlMiddlewareFacts.cs
@@ -93,7 +93,9 @@ public class IndexHtmlMiddlewareFacts
         // Assert
         Assert.IsFalse(_nextCalled);
         Assert.IsNotNull(capturedHtml);
-        Assert.AreEqual("""<html><head><base href="http://localhost/httplaceholder"><script type="text/javascript">window.rootUrl = "http://localhost/httplaceholder";</script></head><body></body></html>""", capturedHtml);
+        Assert.AreEqual(
+            """<html><head><base href="http://localhost/httplaceholder"><script type="text/javascript">window.rootUrl = "http://localhost/httplaceholder";</script></head><body></body></html>""",
+            capturedHtml);
         httpContextServiceMock.Verify(m => m.AddHeader(HeaderKeys.ContentType, MimeTypes.HtmlMime));
     }
 

--- a/src/HttPlaceholder.Web.Shared.Tests/Middleware/IndexHtmlMiddlewareFacts.cs
+++ b/src/HttPlaceholder.Web.Shared.Tests/Middleware/IndexHtmlMiddlewareFacts.cs
@@ -1,0 +1,145 @@
+﻿using HtmlAgilityPack;
+using HttPlaceholder.Application.Interfaces.Http;
+using HttPlaceholder.Common;
+using HttPlaceholder.Web.Shared.Middleware;
+using Microsoft.AspNetCore.Http;
+
+namespace HttPlaceholder.Web.Shared.Tests.Middleware;
+
+[TestClass]
+public class IndexHtmlMiddlewareFacts
+{
+    private const string UiPath = "/var/httplaceholder/ui";
+    private readonly AutoMocker _mocker = new();
+    private bool _nextCalled;
+
+    [TestInitialize]
+    public void Initialize()
+    {
+        _mocker.Use<RequestDelegate>(_ =>
+        {
+            _nextCalled = true;
+            return Task.CompletedTask;
+        });
+        _mocker.Use(UiPath);
+    }
+
+    // [TestCleanup]
+    // public void Cleanup() => _mocker.VerifyAll();
+
+    [TestMethod]
+    public async Task Invoke_PathNotForUi_ShouldContinue()
+    {
+        // Arrange
+        var httpContextServiceMock = _mocker.GetMock<IHttpContextService>();
+        var middleware = _mocker.CreateInstance<IndexHtmlMiddleware>();
+
+        const string path = "/not-ui";
+        httpContextServiceMock
+            .Setup(m => m.Path)
+            .Returns(path);
+
+        // Act
+        await middleware.Invoke(new MockHttpContext());
+
+        // Assert
+        Assert.IsTrue(_nextCalled);
+        httpContextServiceMock
+            .Verify(m => m.WriteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [DataTestMethod]
+    [DataRow("/ph-ui")]
+    [DataRow("/ph-ui/")]
+    [DataRow("/ph-ui/index.html")]
+    public async Task Invoke_PathForUi_ShouldReturnModifiedIndexHtml(string path)
+    {
+        // Arrange
+        var httpContextServiceMock = _mocker.GetMock<IHttpContextService>();
+        var fileServiceMock = _mocker.GetMock<IFileService>();
+        var urlResolverMock = _mocker.GetMock<IUrlResolver>();
+        var htmlServiceMock = _mocker.GetMock<IHtmlService>();
+        var middleware = _mocker.CreateInstance<IndexHtmlMiddleware>();
+        IndexHtmlMiddleware.IndexHtml = null;
+
+        httpContextServiceMock
+            .Setup(m => m.Path)
+            .Returns(path);
+
+        const string indexHtml = "<html><head></head><body></body></html>";
+        fileServiceMock
+            .Setup(m => m.ReadAllTextAsync(Path.Join(UiPath, "index.html"), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(indexHtml);
+
+        const string rootUrl = "http://localhost/httplaceholder";
+        urlResolverMock
+            .Setup(m => m.GetRootUrl())
+            .Returns(rootUrl);
+
+        var doc = new HtmlDocument();
+        doc.LoadHtml(indexHtml);
+        htmlServiceMock
+            .Setup(m => m.ReadHtml(indexHtml))
+            .Returns(doc);
+
+        string capturedHtml = null;
+        httpContextServiceMock
+            .Setup(m => m.WriteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<string, CancellationToken>((h, _) => capturedHtml = h);
+
+        // Act
+        await middleware.Invoke(new MockHttpContext());
+
+        // Assert
+        Assert.IsFalse(_nextCalled);
+        Assert.IsNotNull(capturedHtml);
+        Assert.AreEqual("""<html><head><base href="http://localhost/httplaceholder"><script type="text/javascript">window.rootUrl = "http://localhost/httplaceholder";</script></head><body></body></html>""", capturedHtml);
+        httpContextServiceMock.Verify(m => m.AddHeader(HeaderKeys.ContentType, MimeTypes.HtmlMime));
+    }
+
+    [TestMethod]
+    public async Task Invoke_PathForUi_ShouldCache()
+    {
+        // Arrange
+        var httpContextServiceMock = _mocker.GetMock<IHttpContextService>();
+        var fileServiceMock = _mocker.GetMock<IFileService>();
+        var urlResolverMock = _mocker.GetMock<IUrlResolver>();
+        var htmlServiceMock = _mocker.GetMock<IHtmlService>();
+        var middleware = _mocker.CreateInstance<IndexHtmlMiddleware>();
+
+        httpContextServiceMock
+            .Setup(m => m.Path)
+            .Returns("/ph-ui/index.html");
+
+        const string indexHtml = "<html><head></head><body></body></html>";
+        fileServiceMock
+            .Setup(m => m.ReadAllTextAsync(Path.Join(UiPath, "index.html"), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(indexHtml);
+
+        const string rootUrl = "http://localhost/httplaceholder";
+        urlResolverMock
+            .Setup(m => m.GetRootUrl())
+            .Returns(rootUrl);
+
+        var doc = new HtmlDocument();
+        doc.LoadHtml(indexHtml);
+        htmlServiceMock
+            .Setup(m => m.ReadHtml(indexHtml))
+            .Returns(doc);
+
+        string capturedHtml = null;
+        httpContextServiceMock
+            .Setup(m => m.WriteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<string, CancellationToken>((h, _) => capturedHtml = h);
+
+        // Act
+        await middleware.Invoke(new MockHttpContext());
+        await middleware.Invoke(new MockHttpContext());
+        await middleware.Invoke(new MockHttpContext());
+
+        // Assert
+        Assert.IsFalse(_nextCalled);
+        Assert.IsNotNull(capturedHtml);
+        urlResolverMock.Verify(m => m.GetRootUrl(), Times.Once);
+    }
+}

--- a/src/HttPlaceholder.Web.Shared.Tests/Middleware/StubHandlingMiddlewareFacts.cs
+++ b/src/HttPlaceholder.Web.Shared.Tests/Middleware/StubHandlingMiddlewareFacts.cs
@@ -101,6 +101,7 @@ public class StubHandlingMiddlewareFacts
         var clientDataResolverMock = _mocker.GetMock<IClientDataResolver>();
         var stubContextMock = _mocker.GetMock<IStubContext>();
         var mediatorMock = _mocker.GetMock<IMediator>();
+        var urlResolverMock = _mocker.GetMock<IUrlResolver>();
 
         const string requestPath = "/stub-path";
 
@@ -113,8 +114,8 @@ public class StubHandlingMiddlewareFacts
             .Setup(m => m.Method)
             .Returns(method);
 
-        httpContextServiceMock
-            .Setup(m => m.DisplayUrl)
+        urlResolverMock
+            .Setup(m => m.GetDisplayUrl())
             .Returns(requestPath);
 
         var requestBody = "posted body"u8.ToArray();

--- a/src/HttPlaceholder.Web.Shared/Middleware/IndexHtmlMiddleware.cs
+++ b/src/HttPlaceholder.Web.Shared/Middleware/IndexHtmlMiddleware.cs
@@ -10,7 +10,7 @@ namespace HttPlaceholder.Web.Shared.Middleware;
 /// </summary>
 public class IndexHtmlMiddleware
 {
-    private static string _indexHtml;
+    internal static string IndexHtml;
     private readonly RequestDelegate _next;
     private readonly string _guiPath;
     private readonly IHttpContextService _httpContextService;
@@ -47,7 +47,7 @@ public class IndexHtmlMiddleware
         if (parts.Any(p => path.Equals(p, StringComparison.OrdinalIgnoreCase)))
         {
             var cancellationToken = context?.RequestAborted ?? CancellationToken.None;
-            if (string.IsNullOrWhiteSpace(_indexHtml))
+            if (string.IsNullOrWhiteSpace(IndexHtml))
             {
                 var indexHtml = await _fileService.ReadAllTextAsync(Path.Join(_guiPath, "index.html"), cancellationToken);
                 var rootUrl = _urlResolver.GetRootUrl();
@@ -56,11 +56,11 @@ public class IndexHtmlMiddleware
                 headNode.PrependChild(HtmlNode.CreateNode(
                     @$"<script type=""text/javascript"">window.rootUrl = ""{rootUrl}"";</script>"));
                 headNode.PrependChild(HtmlNode.CreateNode(@$"<base href=""{rootUrl}"">"));
-                _indexHtml = doc.DocumentNode.InnerHtml;
+                IndexHtml = doc.DocumentNode.OuterHtml;
             }
 
-            _httpContextService.AddHeader("Content-Type", MimeTypes.HtmlMime);
-            await _httpContextService.WriteAsync(_indexHtml, cancellationToken);
+            _httpContextService.AddHeader(HeaderKeys.ContentType, MimeTypes.HtmlMime);
+            await _httpContextService.WriteAsync(IndexHtml, cancellationToken);
         }
         else
         {

--- a/src/HttPlaceholder.Web.Shared/Middleware/IndexHtmlMiddleware.cs
+++ b/src/HttPlaceholder.Web.Shared/Middleware/IndexHtmlMiddleware.cs
@@ -11,12 +11,12 @@ namespace HttPlaceholder.Web.Shared.Middleware;
 public class IndexHtmlMiddleware
 {
     internal static string IndexHtml;
-    private readonly RequestDelegate _next;
-    private readonly string _guiPath;
-    private readonly IHttpContextService _httpContextService;
     private readonly IFileService _fileService;
-    private readonly IUrlResolver _urlResolver;
+    private readonly string _guiPath;
     private readonly IHtmlService _htmlService;
+    private readonly IHttpContextService _httpContextService;
+    private readonly RequestDelegate _next;
+    private readonly IUrlResolver _urlResolver;
 
     /// <summary>
     ///     Constructs an <see cref="IndexHtmlMiddleware" /> instance.
@@ -49,7 +49,8 @@ public class IndexHtmlMiddleware
             var cancellationToken = context?.RequestAborted ?? CancellationToken.None;
             if (string.IsNullOrWhiteSpace(IndexHtml))
             {
-                var indexHtml = await _fileService.ReadAllTextAsync(Path.Join(_guiPath, "index.html"), cancellationToken);
+                var indexHtml =
+                    await _fileService.ReadAllTextAsync(Path.Join(_guiPath, "index.html"), cancellationToken);
                 var rootUrl = _urlResolver.GetRootUrl();
                 var doc = _htmlService.ReadHtml(indexHtml);
                 var headNode = doc.DocumentNode.SelectSingleNode("//html/head");

--- a/src/HttPlaceholder.Web.Shared/Middleware/IndexHtmlMiddleware.cs
+++ b/src/HttPlaceholder.Web.Shared/Middleware/IndexHtmlMiddleware.cs
@@ -1,0 +1,70 @@
+﻿using HtmlAgilityPack;
+using HttPlaceholder.Application.Interfaces.Http;
+using HttPlaceholder.Common;
+using HttPlaceholder.Domain;
+
+namespace HttPlaceholder.Web.Shared.Middleware;
+
+/// <summary>
+///     A piece of middleware for handling the index.html file for the UI.
+/// </summary>
+public class IndexHtmlMiddleware
+{
+    private static string _indexHtml;
+    private readonly RequestDelegate _next;
+    private readonly string _guiPath;
+    private readonly IHttpContextService _httpContextService;
+    private readonly IFileService _fileService;
+    private readonly IUrlResolver _urlResolver;
+    private readonly IHtmlService _htmlService;
+
+    /// <summary>
+    ///     Constructs an <see cref="IndexHtmlMiddleware" /> instance.
+    /// </summary>
+    public IndexHtmlMiddleware(
+        RequestDelegate next,
+        string path,
+        IHttpContextService httpContextService,
+        IFileService fileService,
+        IUrlResolver urlResolver,
+        IHtmlService htmlService)
+    {
+        _next = next;
+        _guiPath = path;
+        _httpContextService = httpContextService;
+        _fileService = fileService;
+        _urlResolver = urlResolver;
+        _htmlService = htmlService;
+    }
+
+    /// <summary>
+    ///     Handles the middleware.
+    /// </summary>
+    public async Task Invoke(HttpContext context)
+    {
+        var path = _httpContextService.Path;
+        var parts = new[] {"/ph-ui", "/ph-ui/", "/ph-ui/index.html"};
+        if (parts.Any(p => path.Equals(p, StringComparison.OrdinalIgnoreCase)))
+        {
+            var cancellationToken = context?.RequestAborted ?? CancellationToken.None;
+            if (string.IsNullOrWhiteSpace(_indexHtml))
+            {
+                var indexHtml = await _fileService.ReadAllTextAsync(Path.Join(_guiPath, "index.html"), cancellationToken);
+                var rootUrl = _urlResolver.GetRootUrl();
+                var doc = _htmlService.ReadHtml(indexHtml);
+                var headNode = doc.DocumentNode.SelectSingleNode("//html/head");
+                headNode.PrependChild(HtmlNode.CreateNode(
+                    @$"<script type=""text/javascript"">window.rootUrl = ""{rootUrl}"";</script>"));
+                headNode.PrependChild(HtmlNode.CreateNode(@$"<base href=""{rootUrl}"">"));
+                _indexHtml = doc.DocumentNode.InnerHtml;
+            }
+
+            _httpContextService.AddHeader("Content-Type", MimeTypes.HtmlMime);
+            await _httpContextService.WriteAsync(_indexHtml, cancellationToken);
+        }
+        else
+        {
+            await _next(context);
+        }
+    }
+}

--- a/src/HttPlaceholder.Web.Shared/Middleware/StubHandlingMiddleware.cs
+++ b/src/HttPlaceholder.Web.Shared/Middleware/StubHandlingMiddleware.cs
@@ -22,15 +22,15 @@ public class StubHandlingMiddleware
         "/ph-api", "/ph-ui", "/ph-static", "swagger", "/requestHub", "/scenarioHub", "/stubHub"
     };
 
-    private readonly RequestDelegate _next;
+    private readonly IClientDataResolver _clientDataResolver;
+    private readonly IHttpContextService _httpContextService;
+    private readonly ILogger<StubHandlingMiddleware> _logger;
     private readonly IMediator _mediator;
+    private readonly RequestDelegate _next;
+    private readonly IOptionsMonitor<SettingsModel> _options;
     private readonly IRequestLoggerFactory _requestLoggerFactory;
     private readonly IResourcesService _resourcesService;
     private readonly IStubContext _stubContext;
-    private readonly ILogger<StubHandlingMiddleware> _logger;
-    private readonly IClientDataResolver _clientDataResolver;
-    private readonly IHttpContextService _httpContextService;
-    private readonly IOptionsMonitor<SettingsModel> _options;
     private readonly IUrlResolver _urlResolver;
 
 

--- a/src/HttPlaceholder.Web.Shared/Middleware/StubHandlingMiddleware.cs
+++ b/src/HttPlaceholder.Web.Shared/Middleware/StubHandlingMiddleware.cs
@@ -31,6 +31,7 @@ public class StubHandlingMiddleware
     private readonly IClientDataResolver _clientDataResolver;
     private readonly IHttpContextService _httpContextService;
     private readonly IOptionsMonitor<SettingsModel> _options;
+    private readonly IUrlResolver _urlResolver;
 
 
     /// <summary>
@@ -45,7 +46,8 @@ public class StubHandlingMiddleware
         ILogger<StubHandlingMiddleware> logger,
         IClientDataResolver clientDataResolver,
         IOptionsMonitor<SettingsModel> options,
-        IHttpContextService httpContextService)
+        IHttpContextService httpContextService,
+        IUrlResolver urlResolver)
     {
         _next = next;
         _mediator = mediator;
@@ -55,6 +57,7 @@ public class StubHandlingMiddleware
         _logger = logger;
         _clientDataResolver = clientDataResolver;
         _httpContextService = httpContextService;
+        _urlResolver = urlResolver;
         _options = options;
     }
 
@@ -125,7 +128,7 @@ public class StubHandlingMiddleware
         if (settings?.Gui?.EnableUserInterface == true)
         {
             var pageContents = _resourcesService.ReadAsString("Files/StubNotConfigured.html")
-                .Replace("[ROOT_URL]", _httpContextService.RootUrl);
+                .Replace("[ROOT_URL]", _urlResolver.GetRootUrl());
             _httpContextService.AddHeader(HeaderKeys.ContentType, MimeTypes.HtmlMime);
             await _httpContextService.WriteAsync(pageContents, cancellationToken);
         }
@@ -142,7 +145,7 @@ public class StubHandlingMiddleware
         // Log the request here.
         requestLogger.LogRequestParameters(
             _httpContextService.Method,
-            _httpContextService.DisplayUrl,
+            _urlResolver.GetDisplayUrl(),
             await _httpContextService.GetBodyAsBytesAsync(cancellationToken),
             _clientDataResolver.GetClientIp(),
             _httpContextService.GetHeaders());

--- a/src/HttPlaceholder.Web.Shared/Utilities/StartupUtilities.cs
+++ b/src/HttPlaceholder.Web.Shared/Utilities/StartupUtilities.cs
@@ -53,6 +53,7 @@ public static class StartupUtilities
         var path = $"{AssemblyHelper.GetCallingAssemblyRootPath()}/gui";
         if (Directory.Exists(path))
         {
+            app.UseMiddleware<IndexHtmlMiddleware>(path);
             app.UseFileServer(new FileServerOptions
             {
                 EnableDefaultFiles = true, FileProvider = new PhysicalFileProvider(path), RequestPath = "/ph-ui"

--- a/src/HttPlaceholder.WebInfrastructure.Tests/Implementations/ClientDataResolverFacts.cs
+++ b/src/HttPlaceholder.WebInfrastructure.Tests/Implementations/ClientDataResolverFacts.cs
@@ -1,6 +1,5 @@
 using HttPlaceholder.Application.Configuration;
 using HttPlaceholder.Web.Shared.Infrastructure.Web;
-using Microsoft.AspNetCore.Http;
 
 namespace HttPlaceholder.WebInfrastructure.Tests.Implementations;
 

--- a/src/HttPlaceholder.WebInfrastructure.Tests/Implementations/HtmlServiceFacts.cs
+++ b/src/HttPlaceholder.WebInfrastructure.Tests/Implementations/HtmlServiceFacts.cs
@@ -1,0 +1,22 @@
+﻿using HttPlaceholder.WebInfrastructure.Implementations;
+
+namespace HttPlaceholder.WebInfrastructure.Tests.Implementations;
+
+[TestClass]
+public class HtmlServiceFacts
+{
+    private readonly HtmlService _service = new();
+
+    [TestMethod]
+    public void ReadHtml_HappyFlow()
+    {
+        // Arrange
+        const string html = "<html></html>";
+
+        // Act
+        var result = _service.ReadHtml(html);
+
+        // Assert
+        Assert.AreEqual(html, result.DocumentNode.OuterHtml);
+    }
+}

--- a/src/HttPlaceholder.WebInfrastructure.Tests/Implementations/HttpContextServiceFacts.cs
+++ b/src/HttPlaceholder.WebInfrastructure.Tests/Implementations/HttpContextServiceFacts.cs
@@ -59,56 +59,6 @@ public class HttpContextServiceFacts
         Assert.AreEqual("/path?key1=val1", result);
     }
 
-    [DataTestMethod]
-    [DataRow(false, "httplaceholder.com", "/path", "?key1=val1", "http://httplaceholder.com/path?key1=val1")]
-    [DataRow(true, "httplaceholder.com", "/path", "?key1=val1", "https://httplaceholder.com/path?key1=val1")]
-    [DataRow(true, "httplaceholder.com", "/path", null, "https://httplaceholder.com/path")]
-    public void DisplayUrl_HappyFlow(bool isHttps, string host, string path, string queryString, string expectedUrl)
-    {
-        // Arrange
-        _mockHttpContext.SetRequestPath(path);
-        _mockHttpContext.SetQueryString(queryString);
-
-        var mockClientDataResolver = _mocker.GetMock<IClientDataResolver>();
-        mockClientDataResolver
-            .Setup(m => m.IsHttps())
-            .Returns(isHttps);
-        mockClientDataResolver
-            .Setup(m => m.GetHost())
-            .Returns(host);
-
-        var service = _mocker.CreateInstance<HttpContextService>();
-
-        // Act
-        var result = service.DisplayUrl;
-
-        // Assert
-        Assert.AreEqual(expectedUrl, result);
-    }
-
-    [DataTestMethod]
-    [DataRow(false, "httplaceholder.com", "http://httplaceholder.com")]
-    [DataRow(true, "httplaceholder.com", "https://httplaceholder.com")]
-    public void RootUrl_HappyFlow(bool isHttps, string host, string expectedUrl)
-    {
-        // Arrange
-        var mockClientDataResolver = _mocker.GetMock<IClientDataResolver>();
-        mockClientDataResolver
-            .Setup(m => m.IsHttps())
-            .Returns(isHttps);
-        mockClientDataResolver
-            .Setup(m => m.GetHost())
-            .Returns(host);
-
-        var service = _mocker.CreateInstance<HttpContextService>();
-
-        // Act
-        var result = service.RootUrl;
-
-        // Assert
-        Assert.AreEqual(expectedUrl, result);
-    }
-
     [TestMethod]
     public async Task GetBody_HappyFlow()
     {

--- a/src/HttPlaceholder.WebInfrastructure.Tests/Implementations/HttpContextServiceFacts.cs
+++ b/src/HttPlaceholder.WebInfrastructure.Tests/Implementations/HttpContextServiceFacts.cs
@@ -1,6 +1,5 @@
 ﻿using System.Net;
 using System.Security.Claims;
-using HttPlaceholder.Application.Interfaces.Http;
 using HttPlaceholder.Web.Shared.Infrastructure.Web;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;

--- a/src/HttPlaceholder.WebInfrastructure.Tests/Implementations/LoginCookieServiceFacts.cs
+++ b/src/HttPlaceholder.WebInfrastructure.Tests/Implementations/LoginCookieServiceFacts.cs
@@ -8,8 +8,8 @@ namespace HttPlaceholder.WebInfrastructure.Tests.Implementations;
 [TestClass]
 public class LoginCookieServiceFacts
 {
-    private readonly IOptionsMonitor<SettingsModel> _options = MockSettingsFactory.GetOptionsMonitor();
     private readonly AutoMocker _mocker = new();
+    private readonly IOptionsMonitor<SettingsModel> _options = MockSettingsFactory.GetOptionsMonitor();
 
     [TestInitialize]
     public void Initialize() => _mocker.Use(_options);
@@ -69,7 +69,8 @@ public class LoginCookieServiceFacts
         var httpContextServiceMock = _mocker.GetMock<IHttpContextService>();
         httpContextServiceMock
             .Setup(m => m.GetRequestCookie("HttPlaceholderLoggedin"))
-            .Returns(new KeyValuePair<string, string>("HttPlaceholderLoggedin", "qkUYd4wTaLeznD/nN1v9ei9/5XUekWt1hyOctq3bQZ9DMhSk7FJz+l1ILk++kyYlu+VguxVcuEC9R4Ryk763GA=="));
+            .Returns(new KeyValuePair<string, string>("HttPlaceholderLoggedin",
+                "qkUYd4wTaLeznD/nN1v9ei9/5XUekWt1hyOctq3bQZ9DMhSk7FJz+l1ILk++kyYlu+VguxVcuEC9R4Ryk763GA=="));
         _options.CurrentValue.Authentication.ApiUsername = "user";
         _options.CurrentValue.Authentication.ApiPassword = "pass";
 

--- a/src/HttPlaceholder.WebInfrastructure.Tests/Implementations/UrlResolverFacts.cs
+++ b/src/HttPlaceholder.WebInfrastructure.Tests/Implementations/UrlResolverFacts.cs
@@ -1,0 +1,67 @@
+﻿using HttPlaceholder.Application.Interfaces.Http;
+using HttPlaceholder.WebInfrastructure.Implementations;
+
+namespace HttPlaceholder.WebInfrastructure.Tests.Implementations;
+
+[TestClass]
+public class UrlResolverFacts
+{
+    private readonly AutoMocker _mocker = new();
+    private readonly MockHttpContext _mockHttpContext = new();
+
+    [TestInitialize]
+    public void Initialize() => _mocker.Use(TestObjectFactory.CreateHttpContextAccessor(_mockHttpContext));
+
+    [TestCleanup]
+    public void Cleanup() => _mocker.VerifyAll();
+
+    [DataTestMethod]
+    [DataRow(false, "httplaceholder.com", "/path", "?key1=val1", "http://httplaceholder.com/path?key1=val1")]
+    [DataRow(true, "httplaceholder.com", "/path", "?key1=val1", "https://httplaceholder.com/path?key1=val1")]
+    [DataRow(true, "httplaceholder.com", "/path", null, "https://httplaceholder.com/path")]
+    public void GetDisplayUrl_HappyFlow(bool isHttps, string host, string path, string queryString, string expectedUrl)
+    {
+        // Arrange
+        _mockHttpContext.SetRequestPath(path);
+        _mockHttpContext.SetQueryString(queryString);
+
+        var mockClientDataResolver = _mocker.GetMock<IClientDataResolver>();
+        mockClientDataResolver
+            .Setup(m => m.IsHttps())
+            .Returns(isHttps);
+        mockClientDataResolver
+            .Setup(m => m.GetHost())
+            .Returns(host);
+
+        var resolver = _mocker.CreateInstance<UrlResolver>();
+
+        // Act
+        var result = resolver.GetDisplayUrl();
+
+        // Assert
+        Assert.AreEqual(expectedUrl, result);
+    }
+
+    [DataTestMethod]
+    [DataRow(false, "httplaceholder.com", "http://httplaceholder.com")]
+    [DataRow(true, "httplaceholder.com", "https://httplaceholder.com")]
+    public void GetRootUrl_HappyFlow(bool isHttps, string host, string expectedUrl)
+    {
+        // Arrange
+        var mockClientDataResolver = _mocker.GetMock<IClientDataResolver>();
+        mockClientDataResolver
+            .Setup(m => m.IsHttps())
+            .Returns(isHttps);
+        mockClientDataResolver
+            .Setup(m => m.GetHost())
+            .Returns(host);
+
+        var resolver = _mocker.CreateInstance<UrlResolver>();
+
+        // Act
+        var result = resolver.GetRootUrl();
+
+        // Assert
+        Assert.AreEqual(expectedUrl, result);
+    }
+}

--- a/src/HttPlaceholder.WebInfrastructure.Tests/Implementations/UrlResolverFacts.cs
+++ b/src/HttPlaceholder.WebInfrastructure.Tests/Implementations/UrlResolverFacts.cs
@@ -20,8 +20,10 @@ public class UrlResolverFacts
     [DataRow(false, "httplaceholder.com", "/path", "?key1=val1", null, "http://httplaceholder.com/path?key1=val1")]
     [DataRow(true, "httplaceholder.com", "/path", "?key1=val1", null, "https://httplaceholder.com/path?key1=val1")]
     [DataRow(true, "httplaceholder.com", "/path", null, null, "https://httplaceholder.com/path")]
-    [DataRow(true, "httplaceholder.com", "/path", "?key1=val1", "https://example.com/stubs/", "https://example.com/stubs/path?key1=val1")]
-    [DataRow(true, "httplaceholder.com", "/path", "?key1=val1", "https://example.com/stubs", "https://example.com/stubs/path?key1=val1")]
+    [DataRow(true, "httplaceholder.com", "/path", "?key1=val1", "https://example.com/stubs/",
+        "https://example.com/stubs/path?key1=val1")]
+    [DataRow(true, "httplaceholder.com", "/path", "?key1=val1", "https://example.com/stubs",
+        "https://example.com/stubs/path?key1=val1")]
     public void GetDisplayUrl_HappyFlow(
         bool isHttps,
         string host,
@@ -38,7 +40,7 @@ public class UrlResolverFacts
         {
             var options = MockSettingsFactory.GetOptionsMonitor(new SettingsModel
             {
-                Web = new WebSettingsModel() {PublicUrl = configuredPublicUrl}
+                Web = new WebSettingsModel {PublicUrl = configuredPublicUrl}
             });
             _mocker.Use(options);
         }
@@ -78,7 +80,7 @@ public class UrlResolverFacts
         {
             var options = MockSettingsFactory.GetOptionsMonitor(new SettingsModel
             {
-                Web = new WebSettingsModel() {PublicUrl = configuredPublicUrl}
+                Web = new WebSettingsModel {PublicUrl = configuredPublicUrl}
             });
             _mocker.Use(options);
         }

--- a/src/HttPlaceholder.WebInfrastructure.Tests/Implementations/UrlResolverFacts.cs
+++ b/src/HttPlaceholder.WebInfrastructure.Tests/Implementations/UrlResolverFacts.cs
@@ -1,4 +1,5 @@
-﻿using HttPlaceholder.Application.Interfaces.Http;
+﻿using HttPlaceholder.Application.Configuration;
+using HttPlaceholder.Application.Interfaces.Http;
 using HttPlaceholder.WebInfrastructure.Implementations;
 
 namespace HttPlaceholder.WebInfrastructure.Tests.Implementations;
@@ -16,22 +17,41 @@ public class UrlResolverFacts
     public void Cleanup() => _mocker.VerifyAll();
 
     [DataTestMethod]
-    [DataRow(false, "httplaceholder.com", "/path", "?key1=val1", "http://httplaceholder.com/path?key1=val1")]
-    [DataRow(true, "httplaceholder.com", "/path", "?key1=val1", "https://httplaceholder.com/path?key1=val1")]
-    [DataRow(true, "httplaceholder.com", "/path", null, "https://httplaceholder.com/path")]
-    public void GetDisplayUrl_HappyFlow(bool isHttps, string host, string path, string queryString, string expectedUrl)
+    [DataRow(false, "httplaceholder.com", "/path", "?key1=val1", null, "http://httplaceholder.com/path?key1=val1")]
+    [DataRow(true, "httplaceholder.com", "/path", "?key1=val1", null, "https://httplaceholder.com/path?key1=val1")]
+    [DataRow(true, "httplaceholder.com", "/path", null, null, "https://httplaceholder.com/path")]
+    [DataRow(true, "httplaceholder.com", "/path", "?key1=val1", "https://example.com/stubs/", "https://example.com/stubs/path?key1=val1")]
+    [DataRow(true, "httplaceholder.com", "/path", "?key1=val1", "https://example.com/stubs", "https://example.com/stubs/path?key1=val1")]
+    public void GetDisplayUrl_HappyFlow(
+        bool isHttps,
+        string host,
+        string path,
+        string queryString,
+        string configuredPublicUrl,
+        string expectedUrl)
     {
         // Arrange
         _mockHttpContext.SetRequestPath(path);
         _mockHttpContext.SetQueryString(queryString);
 
-        var mockClientDataResolver = _mocker.GetMock<IClientDataResolver>();
-        mockClientDataResolver
-            .Setup(m => m.IsHttps())
-            .Returns(isHttps);
-        mockClientDataResolver
-            .Setup(m => m.GetHost())
-            .Returns(host);
+        if (!string.IsNullOrWhiteSpace(configuredPublicUrl))
+        {
+            var options = MockSettingsFactory.GetOptionsMonitor(new SettingsModel
+            {
+                Web = new WebSettingsModel() {PublicUrl = configuredPublicUrl}
+            });
+            _mocker.Use(options);
+        }
+        else
+        {
+            var mockClientDataResolver = _mocker.GetMock<IClientDataResolver>();
+            mockClientDataResolver
+                .Setup(m => m.IsHttps())
+                .Returns(isHttps);
+            mockClientDataResolver
+                .Setup(m => m.GetHost())
+                .Returns(host);
+        }
 
         var resolver = _mocker.CreateInstance<UrlResolver>();
 
@@ -43,18 +63,35 @@ public class UrlResolverFacts
     }
 
     [DataTestMethod]
-    [DataRow(false, "httplaceholder.com", "http://httplaceholder.com")]
-    [DataRow(true, "httplaceholder.com", "https://httplaceholder.com")]
-    public void GetRootUrl_HappyFlow(bool isHttps, string host, string expectedUrl)
+    [DataRow(false, "httplaceholder.com", null, "http://httplaceholder.com")]
+    [DataRow(true, "httplaceholder.com", null, "https://httplaceholder.com")]
+    [DataRow(true, "httplaceholder.com", "https://example.com/stubs", "https://example.com/stubs")]
+    [DataRow(true, "httplaceholder.com", "https://example.com/stubs/", "https://example.com/stubs")]
+    public void GetRootUrl_HappyFlow(
+        bool isHttps,
+        string host,
+        string configuredPublicUrl,
+        string expectedUrl)
     {
         // Arrange
-        var mockClientDataResolver = _mocker.GetMock<IClientDataResolver>();
-        mockClientDataResolver
-            .Setup(m => m.IsHttps())
-            .Returns(isHttps);
-        mockClientDataResolver
-            .Setup(m => m.GetHost())
-            .Returns(host);
+        if (!string.IsNullOrWhiteSpace(configuredPublicUrl))
+        {
+            var options = MockSettingsFactory.GetOptionsMonitor(new SettingsModel
+            {
+                Web = new WebSettingsModel() {PublicUrl = configuredPublicUrl}
+            });
+            _mocker.Use(options);
+        }
+        else
+        {
+            var mockClientDataResolver = _mocker.GetMock<IClientDataResolver>();
+            mockClientDataResolver
+                .Setup(m => m.IsHttps())
+                .Returns(isHttps);
+            mockClientDataResolver
+                .Setup(m => m.GetHost())
+                .Returns(host);
+        }
 
         var resolver = _mocker.CreateInstance<UrlResolver>();
 

--- a/src/HttPlaceholder.WebInfrastructure/Implementations/ApiAuthorizationService.cs
+++ b/src/HttPlaceholder.WebInfrastructure/Implementations/ApiAuthorizationService.cs
@@ -10,10 +10,10 @@ namespace HttPlaceholder.WebInfrastructure.Implementations;
 
 internal class ApiAuthorizationService : IApiAuthorizationService, ISingletonService
 {
+    private readonly IHttpContextService _httpContextService;
+    private readonly ILogger<ApiAuthorizationService> _logger;
     private readonly ILoginCookieService _loginCookieService;
     private readonly SettingsModel _settings;
-    private readonly ILogger<ApiAuthorizationService> _logger;
-    private readonly IHttpContextService _httpContextService;
 
     public ApiAuthorizationService(
         ILoginCookieService loginCookieService,

--- a/src/HttPlaceholder.WebInfrastructure/Implementations/HtmlService.cs
+++ b/src/HttPlaceholder.WebInfrastructure/Implementations/HtmlService.cs
@@ -1,0 +1,19 @@
+﻿using HtmlAgilityPack;
+using HttPlaceholder.Application.Infrastructure.DependencyInjection;
+using HttPlaceholder.Application.Interfaces.Http;
+
+namespace HttPlaceholder.WebInfrastructure.Implementations;
+
+/// <summary>
+///     A class that is used to work with and manipulate HTML.
+/// </summary>
+public class HtmlService : IHtmlService, ISingletonService
+{
+    /// <inheritdoc />
+    public HtmlDocument ReadHtml(string html)
+    {
+        var doc = new HtmlDocument();
+        doc.LoadHtml(html);
+        return doc;
+    }
+}

--- a/src/HttPlaceholder.WebInfrastructure/Implementations/HttpContextService.cs
+++ b/src/HttPlaceholder.WebInfrastructure/Implementations/HttpContextService.cs
@@ -40,32 +40,6 @@ internal class HttpContextService : IHttpContextService, ISingletonService
         $"{_httpContextAccessor.HttpContext.Request.Path}{_httpContextAccessor.HttpContext.Request.QueryString}";
 
     /// <inheritdoc />
-    public string DisplayUrl
-    {
-        get
-        {
-            var proto = _clientDataResolver.IsHttps() ? "https" : "http";
-            var host = _clientDataResolver.GetHost();
-            string path = _httpContextAccessor.HttpContext.Request.Path;
-            var query = _httpContextAccessor.HttpContext.Request.QueryString.HasValue
-                ? _httpContextAccessor.HttpContext.Request.QueryString.Value
-                : string.Empty;
-            return $"{proto}://{host}{path}{query}";
-        }
-    }
-
-    /// <inheritdoc />
-    public string RootUrl
-    {
-        get
-        {
-            var proto = _clientDataResolver.IsHttps() ? "https" : "http";
-            var host = _clientDataResolver.GetHost();
-            return $"{proto}://{host}";
-        }
-    }
-
-    /// <inheritdoc />
     public async Task<string> GetBodyAsync(CancellationToken cancellationToken) =>
         Encoding.UTF8.GetString(await GetBodyAsBytesAsync(cancellationToken));
 

--- a/src/HttPlaceholder.WebInfrastructure/Implementations/UrlResolver.cs
+++ b/src/HttPlaceholder.WebInfrastructure/Implementations/UrlResolver.cs
@@ -1,0 +1,36 @@
+﻿using HttPlaceholder.Application.Infrastructure.DependencyInjection;
+using HttPlaceholder.Application.Interfaces.Http;
+
+namespace HttPlaceholder.WebInfrastructure.Implementations;
+
+internal class UrlResolver : IUrlResolver, ISingletonService
+{
+    private readonly IClientDataResolver _clientDataResolver;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public UrlResolver(
+        IClientDataResolver clientDataResolver,
+        IHttpContextAccessor httpContextAccessor)
+    {
+        _clientDataResolver = clientDataResolver;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public string GetDisplayUrl()
+    {
+        var proto = _clientDataResolver.IsHttps() ? "https" : "http";
+        var host = _clientDataResolver.GetHost();
+        string path = _httpContextAccessor.HttpContext.Request.Path;
+        var query = _httpContextAccessor.HttpContext.Request.QueryString.HasValue
+            ? _httpContextAccessor.HttpContext.Request.QueryString.Value
+            : string.Empty;
+        return $"{proto}://{host}{path}{query}";
+    }
+
+    public string GetRootUrl()
+    {
+        var proto = _clientDataResolver.IsHttps() ? "https" : "http";
+        var host = _clientDataResolver.GetHost();
+        return $"{proto}://{host}";
+    }
+}

--- a/src/HttPlaceholder.WebInfrastructure/Implementations/UrlResolver.cs
+++ b/src/HttPlaceholder.WebInfrastructure/Implementations/UrlResolver.cs
@@ -1,5 +1,8 @@
-﻿using HttPlaceholder.Application.Infrastructure.DependencyInjection;
+﻿using HttPlaceholder.Application.Configuration;
+using HttPlaceholder.Application.Infrastructure.DependencyInjection;
 using HttPlaceholder.Application.Interfaces.Http;
+using HttPlaceholder.Common.Utilities;
+using Microsoft.Extensions.Options;
 
 namespace HttPlaceholder.WebInfrastructure.Implementations;
 
@@ -7,28 +10,36 @@ internal class UrlResolver : IUrlResolver, ISingletonService
 {
     private readonly IClientDataResolver _clientDataResolver;
     private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IOptionsMonitor<SettingsModel> _options;
 
     public UrlResolver(
         IClientDataResolver clientDataResolver,
-        IHttpContextAccessor httpContextAccessor)
+        IHttpContextAccessor httpContextAccessor,
+        IOptionsMonitor<SettingsModel> options)
     {
         _clientDataResolver = clientDataResolver;
         _httpContextAccessor = httpContextAccessor;
+        _options = options;
     }
 
     public string GetDisplayUrl()
     {
-        var proto = _clientDataResolver.IsHttps() ? "https" : "http";
-        var host = _clientDataResolver.GetHost();
+        var rootUrl = GetRootUrl();
         string path = _httpContextAccessor.HttpContext.Request.Path;
         var query = _httpContextAccessor.HttpContext.Request.QueryString.HasValue
             ? _httpContextAccessor.HttpContext.Request.QueryString.Value
             : string.Empty;
-        return $"{proto}://{host}{path}{query}";
+        return $"{rootUrl}{path}{query}";
     }
 
     public string GetRootUrl()
     {
+        var settings = _options.CurrentValue;
+        if (!string.IsNullOrWhiteSpace(settings?.Web?.PublicUrl))
+        {
+            return settings.Web.PublicUrl.EnsureDoesntEndWith('/');
+        }
+
         var proto = _clientDataResolver.IsHttps() ? "https" : "http";
         var host = _clientDataResolver.GetHost();
         return $"{proto}://{host}";

--- a/src/HttPlaceholder/.gitignore
+++ b/src/HttPlaceholder/.gitignore
@@ -1,2 +1,2 @@
-!gui/.gitkeep
-gui/
+gui/*
+!gui/index.html

--- a/src/HttPlaceholder/Controllers/v1/RequestController.cs
+++ b/src/HttPlaceholder/Controllers/v1/RequestController.cs
@@ -27,27 +27,36 @@ public class RequestController : BaseApiController
     ///     Get all Requests.
     /// </summary>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <param name="fromIdentifier">The identifier from which to find items. If this is not set; means to query from the start.</param>
+    /// <param name="fromIdentifier">
+    ///     The identifier from which to find items. If this is not set; means to query from the
+    ///     start.
+    /// </param>
     /// <param name="itemsPerPage">The number of items to show on a page.</param>
     /// <returns>All request results</returns>
     [HttpGet]
     [ProducesResponseType(StatusCodes.Status200OK)]
     public async Task<ActionResult<IEnumerable<RequestResultDto>>> GetAll(CancellationToken cancellationToken,
-        [FromHeader(Name = "x-from-identifier")] string fromIdentifier, [FromHeader(Name = "x-items-per-page")] int? itemsPerPage) =>
-        Ok(Mapper.Map<IEnumerable<RequestResultDto>>(await Mediator.Send(new GetAllRequestsQuery(fromIdentifier, itemsPerPage),
+        [FromHeader(Name = "x-from-identifier")]
+        string fromIdentifier, [FromHeader(Name = "x-items-per-page")] int? itemsPerPage) =>
+        Ok(Mapper.Map<IEnumerable<RequestResultDto>>(await Mediator.Send(
+            new GetAllRequestsQuery(fromIdentifier, itemsPerPage),
             cancellationToken)));
 
     /// <summary>
     ///     Get overview of all Requests.
     /// </summary>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <param name="fromIdentifier">The identifier from which to find items. If this is not set; means to query from the start.</param>
+    /// <param name="fromIdentifier">
+    ///     The identifier from which to find items. If this is not set; means to query from the
+    ///     start.
+    /// </param>
     /// <param name="itemsPerPage">The number of items to show on a page.</param>
     /// <returns>All request results</returns>
     [HttpGet("overview")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     public async Task<ActionResult<IEnumerable<RequestOverviewDto>>> GetOverview(CancellationToken cancellationToken,
-        [FromHeader(Name = "x-from-identifier")] string fromIdentifier, [FromHeader(Name = "x-items-per-page")] int? itemsPerPage) =>
+        [FromHeader(Name = "x-from-identifier")]
+        string fromIdentifier, [FromHeader(Name = "x-items-per-page")] int? itemsPerPage) =>
         Ok(Mapper.Map<IEnumerable<RequestOverviewDto>>(await Mediator.Send(
             new GetRequestsOverviewQuery(fromIdentifier, itemsPerPage),
             cancellationToken)));

--- a/src/HttPlaceholder/gui/index.html
+++ b/src/HttPlaceholder/gui/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8"/>
+    <link rel="icon" href="favicon.ico"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>HttPlaceholder</title>
+</head>
+<body>
+<div id="app"></div>
+</body>
+</html>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

In the old situation, the root URL of HttPlaceholder was determined dynamically by looking at the current host, port etc. This root URL was also only used within the API, not in the UI, which made it a lot harder to run HttPlaceholder with the UI behind a reverse proxy.

## What is the new behavior?

Added new `publicUrl` property which makes it possible to assign a root URL for both HttPlaceholder and the UI. Useful if you run HttPlaceholder behind a reverse proxy

## Does this introduce a breaking change?

- [ ] Yes
- [X] No