### PR TITLE
Release 2024.2.24.160

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@
 - Whenever a YAML file is updated, the change should be reflected in the user interface using web sockets (https://github.com/dukeofharen/httplaceholder/pull/340).
 - Fixed behavior in the frontend that, when uploading stubs through the upload button, the API is not DDOSed (which some stub sources like the SQLite stub source did not like) (https://github.com/dukeofharen/httplaceholder/pull/342).
 - Several fixes in the handling of form data within HttPlaceholder (https://github.com/dukeofharen/httplaceholder/pull/343).
+- Update form helpers so it is much easier to update a stub using the UI (https://github.com/dukeofharen/httplaceholder/pull/344).
 
 # BREAKING CHANGES
 - If you installed HttPlaceholder as .NET tool, you need to have the .NET 8 SDK installed on your machine. If you download the compiled version of HttPlaceholder for your OS, you do not need to have .NET installed so you will notice no changes.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-[vnext]
+[2024.2.24]
 - Upgraded application to .NET 8 (https://github.com/dukeofharen/httplaceholder/pull/338).
 - Use file watches to check if the .yml stub files are updated on disk (https://github.com/dukeofharen/httplaceholder/pull/339).
 - When using YAML stubs; show the file location of the YAML stub in the user interface (https://github.com/dukeofharen/httplaceholder/pull/340).

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Also visit the website: https://httplaceholder.org/
 
 ### Built With
 
-- [.NET 6](https://dotnet.microsoft.com/apps/aspnet)
+- [.NET 8](https://dotnet.microsoft.com/apps/aspnet)
 - [Vue.js](https://vuejs.org/)
 - [Bootstrap](https://getbootstrap.com/)
 - [CodeMirror](https://codemirror.net/)

--- a/src/HttPlaceholder.Application.Tests/HttPlaceholder.Application.Tests.csproj
+++ b/src/HttPlaceholder.Application.Tests/HttPlaceholder.Application.Tests.csproj
@@ -12,10 +12,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
         <PackageReference Include="Moq.AutoMock" Version="3.5.0" />
-        <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-        <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+        <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
+        <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
         <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
     </ItemGroup>
 

--- a/src/HttPlaceholder.Application/HttPlaceholder.Application.csproj
+++ b/src/HttPlaceholder.Application/HttPlaceholder.Application.csproj
@@ -8,23 +8,22 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1"/>
-        <PackageReference Include="Bogus" Version="34.0.2"/>
-        <PackageReference Include="HtmlAgilityPack" Version="1.11.54" />
+        <PackageReference Include="Bogus" Version="35.4.0" />
+        <PackageReference Include="HtmlAgilityPack" Version="1.11.59" />
         <PackageReference Include="IPAddressRange" Version="6.0.0" />
         <PackageReference Include="MediatR" Version="12.2.0" />
         <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="5.0.17"/>
-        <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.2" />
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" />
-        <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.11" />
+        <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.13" />
         <PackageReference Include="NCrontab" Version="3.3.3" />
-        <PackageReference Include="SixLabors.ImageSharp" Version="3.0.2" />
-        <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.0.1" />
+        <PackageReference Include="SixLabors.ImageSharp" Version="3.1.2" />
+        <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/HttPlaceholder.Client.Tests/HttPlaceholder.Client.Tests.csproj
+++ b/src/HttPlaceholder.Client.Tests/HttPlaceholder.Client.Tests.csproj
@@ -8,10 +8,10 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-        <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-        <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
+        <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
+        <PackageReference Include="coverlet.collector" Version="6.0.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/HttPlaceholder.Client/HttPlaceholder.Client.csproj
+++ b/src/HttPlaceholder.Client/HttPlaceholder.Client.csproj
@@ -23,7 +23,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />

--- a/src/HttPlaceholder.Common.Tests/HttPlaceholder.Common.Tests.csproj
+++ b/src/HttPlaceholder.Common.Tests/HttPlaceholder.Common.Tests.csproj
@@ -7,10 +7,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-        <PackageReference Include="Moq" Version="4.20.69" />
-        <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-        <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <PackageReference Include="Moq" Version="4.20.70" />
+        <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
+        <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/HttPlaceholder.Common/HttPlaceholder.Common.csproj
+++ b/src/HttPlaceholder.Common/HttPlaceholder.Common.csproj
@@ -8,14 +8,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoMapper" Version="12.0.1" />
+        <PackageReference Include="AutoMapper" Version="13.0.1" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="Scrutor" Version="4.2.2" />
-        <PackageReference Include="SixLabors.ImageSharp" Version="3.0.2" />
-        <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.0.1" />
+        <PackageReference Include="SixLabors.ImageSharp" Version="3.1.2" />
+        <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.1" />
         <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-        <PackageReference Include="YamlDotNet" Version="13.7.1" />
+        <PackageReference Include="YamlDotNet" Version="15.1.1" />
     </ItemGroup>
 
 </Project>

--- a/src/HttPlaceholder.Domain.Tests/HttPlaceholder.Domain.Tests.csproj
+++ b/src/HttPlaceholder.Domain.Tests/HttPlaceholder.Domain.Tests.csproj
@@ -7,9 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-        <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-        <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
+        <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/HttPlaceholder.Domain/HttPlaceholder.Domain.csproj
+++ b/src/HttPlaceholder.Domain/HttPlaceholder.Domain.csproj
@@ -9,7 +9,7 @@
 
     <ItemGroup>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-        <PackageReference Include="YamlDotNet" Version="13.7.1" />
+        <PackageReference Include="YamlDotNet" Version="15.1.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/HttPlaceholder.Infrastructure.Tests/HttPlaceholder.Infrastructure.Tests.csproj
+++ b/src/HttPlaceholder.Infrastructure.Tests/HttPlaceholder.Infrastructure.Tests.csproj
@@ -16,10 +16,10 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
         <PackageReference Include="Moq.AutoMock" Version="3.5.0" />
-        <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-        <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+        <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
+        <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/HttPlaceholder.Persistence.Tests/HttPlaceholder.Persistence.Tests.csproj
+++ b/src/HttPlaceholder.Persistence.Tests/HttPlaceholder.Persistence.Tests.csproj
@@ -12,11 +12,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-        <PackageReference Include="Moq" Version="4.20.69" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <PackageReference Include="Moq" Version="4.20.70" />
         <PackageReference Include="Moq.AutoMock" Version="3.5.0" />
-        <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-        <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+        <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
+        <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/HttPlaceholder.Persistence/HttPlaceholder.Persistence.csproj
+++ b/src/HttPlaceholder.Persistence/HttPlaceholder.Persistence.csproj
@@ -9,14 +9,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Dapper" Version="2.1.24" />
+        <PackageReference Include="Dapper" Version="2.1.28" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
-        <PackageReference Include="MySqlConnector" Version="2.3.1" />
-        <PackageReference Include="Npgsql" Version="8.0.0" />
-        <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+        <PackageReference Include="MySqlConnector" Version="2.3.5" />
+        <PackageReference Include="Npgsql" Version="8.0.2" />
+        <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
         <PackageReference Include="System.Data.SQLite" Version="1.0.118" />
     </ItemGroup>
     <ItemGroup>

--- a/src/HttPlaceholder.Resources.Tests/HttPlaceholder.Resources.Tests.csproj
+++ b/src/HttPlaceholder.Resources.Tests/HttPlaceholder.Resources.Tests.csproj
@@ -14,10 +14,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-        <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-        <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
-        <PackageReference Include="Moq" Version="4.20.69" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
+        <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
+        <PackageReference Include="Moq" Version="4.20.70" />
         <PackageReference Include="Moq.AutoMock" Version="3.5.0" />
     </ItemGroup>
 

--- a/src/HttPlaceholder.SwaggerGenerator/HttPlaceholder.SwaggerGenerator.csproj
+++ b/src/HttPlaceholder.SwaggerGenerator/HttPlaceholder.SwaggerGenerator.csproj
@@ -13,7 +13,7 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\HttPlaceholder\HttPlaceholder.csproj" />

--- a/src/HttPlaceholder.TestUtilities/HttPlaceholder.TestUtilities.csproj
+++ b/src/HttPlaceholder.TestUtilities/HttPlaceholder.TestUtilities.csproj
@@ -19,7 +19,7 @@
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Moq" Version="4.20.69" />
+        <PackageReference Include="Moq" Version="4.20.70" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\HttPlaceholder.Application\HttPlaceholder.Application.csproj" />

--- a/src/HttPlaceholder.Tests/HttPlaceholder.Tests.csproj
+++ b/src/HttPlaceholder.Tests/HttPlaceholder.Tests.csproj
@@ -21,13 +21,13 @@
         <WarningsAsErrors />
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.2" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-        <PackageReference Include="Moq" Version="4.20.69" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <PackageReference Include="Moq" Version="4.20.70" />
         <PackageReference Include="Moq.AutoMock" Version="3.5.0" />
-        <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-        <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+        <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
+        <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
         <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
     </ItemGroup>
     <ItemGroup>

--- a/src/HttPlaceholder.Web.Shared.Tests/HttPlaceholder.Web.Shared.Tests.csproj
+++ b/src/HttPlaceholder.Web.Shared.Tests/HttPlaceholder.Web.Shared.Tests.csproj
@@ -12,11 +12,11 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-        <PackageReference Include="Moq" Version="4.20.69" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <PackageReference Include="Moq" Version="4.20.70" />
         <PackageReference Include="Moq.AutoMock" Version="3.5.0" />
-        <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-        <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+        <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
+        <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
         <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
     </ItemGroup>
 

--- a/src/HttPlaceholder.Web.Shared/HttPlaceholder.Web.Shared.csproj
+++ b/src/HttPlaceholder.Web.Shared/HttPlaceholder.Web.Shared.csproj
@@ -21,13 +21,13 @@
         <ProjectReference Include="..\HttPlaceholder.WebInfrastructure\HttPlaceholder.WebInfrastructure.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="NSwag.AspNetCore" Version="14.0.0-preview010" />
+        <PackageReference Include="NSwag.AspNetCore" Version="14.0.3" />
         <PackageReference Include="Serilog" Version="3.1.1" />
-        <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
-        <PackageReference Include="Serilog.Sinks.Console" Version="5.0.0" />
-        <PackageReference Include="YamlDotNet" Version="13.7.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+        <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
+        <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
+        <PackageReference Include="YamlDotNet" Version="15.1.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.2" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="8.0.2" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
     </ItemGroup>
 </Project>

--- a/src/HttPlaceholder.WebInfrastructure.Tests/HttPlaceholder.WebInfrastructure.Tests.csproj
+++ b/src/HttPlaceholder.WebInfrastructure.Tests/HttPlaceholder.WebInfrastructure.Tests.csproj
@@ -11,11 +11,11 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-        <PackageReference Include="Moq" Version="4.20.69" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <PackageReference Include="Moq" Version="4.20.70" />
         <PackageReference Include="Moq.AutoMock" Version="3.5.0" />
-        <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-        <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+        <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
+        <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Upgrade NuGet packages and released version [2024.2.24.160](https://github.com/dukeofharen/httplaceholder/releases/tag/untagged-40b81d7f8d7637f7d14d) of HttPlaceholder.